### PR TITLE
Add throttling to prevent task queue overflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-notify"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b31189a260b12d7159e91b74d0b94bb0be3705237082709611b53342b2fb65d7"
+dependencies = [
+ "event-listener",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-once-cell"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +508,7 @@ dependencies = [
  "async-fs",
  "async-io",
  "async-lock",
+ "async-notify",
  "async-ringbuf",
  "async-stream",
  "async-trait",

--- a/crates/bolt-load/Cargo.toml
+++ b/crates/bolt-load/Cargo.toml
@@ -100,6 +100,7 @@ tracing = { version = "0.1", optional = true }
 
 # terminal progress
 indicatif = { version = "0.18", optional = true }
+async-notify = "0.3.2"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = [

--- a/crates/bolt-load/src/task/instance/concurrent_task/file_writer.rs
+++ b/crates/bolt-load/src/task/instance/concurrent_task/file_writer.rs
@@ -10,6 +10,7 @@ mod mmap;
 mod metrics;
 mod null;
 mod pool;
+mod write_budget;
 
 use std::{
     ops::Range,
@@ -27,6 +28,7 @@ pub use self::compio::CompioWriterBuilder;
 pub use self::mmap::MmapWriterBuilder;
 use self::{null::NullWriter, pool::PoolWriter};
 pub use self::metrics::{FileWriterMetrics, MetricsSnapshot};
+pub use self::write_budget::WriteBudget;
 // Re-export builders for benchmarking and advanced usage
 pub use self::{null::NullWriterBuilder, pool::PoolWriterBuilder};
 use crate::runtime::yield_now;
@@ -190,6 +192,7 @@ pub struct FileWriter {
     pub kind: FileRangeWriterKind,
     inner: Arc<FileRangeWriterImpl>,
     metrics: FileWriterMetrics,
+    budget: Option<WriteBudget>,
 }
 
 impl FileWriter {
@@ -247,13 +250,41 @@ impl FileWriter {
             kind,
             inner: Arc::new(inner),
             metrics,
+            budget: None,
         })
+    }
+
+    /// Set the write budget for backpressure control
+    ///
+    /// This enables runner-level flow control to prevent memory exhaustion
+    /// when disk I/O is slower than network download.
+    pub fn with_budget(mut self, budget: WriteBudget) -> Self {
+        self.budget = Some(budget);
+        self
+    }
+
+    /// Get the write budget if set
+    pub fn budget(&self) -> Option<&WriteBudget> {
+        self.budget.as_ref()
     }
 }
 
 impl FileRangeWriter for FileWriter {
     async fn write_range(&self, range: Range<u64>, data: Bytes) -> Result<(), FileWriterError> {
-        self.inner.write_range(range, data).await
+        let data_len = data.len();
+
+        // Perform the actual write
+        let result = self.inner.write_range(range, data).await;
+
+        // If write succeeded and budget is set, refill the budget
+        // This allows waiting runners to acquire more budget and continue downloading
+        if result.is_ok() {
+            if let Some(budget) = &self.budget {
+                budget.refill(data_len);
+            }
+        }
+
+        result
     }
 
     async fn finalize(self) -> Result<(), FileWriterError> {

--- a/crates/bolt-load/src/task/instance/concurrent_task/file_writer.rs
+++ b/crates/bolt-load/src/task/instance/concurrent_task/file_writer.rs
@@ -7,6 +7,7 @@
 mod compio;
 #[cfg(feature = "mmap")]
 mod mmap;
+mod metrics;
 mod null;
 mod pool;
 
@@ -25,11 +26,12 @@ pub use self::compio::CompioWriterBuilder;
 #[cfg(feature = "mmap")]
 pub use self::mmap::MmapWriterBuilder;
 use self::{null::NullWriter, pool::PoolWriter};
+pub use self::metrics::{FileWriterMetrics, MetricsSnapshot};
 // Re-export builders for benchmarking and advanced usage
 pub use self::{null::NullWriterBuilder, pool::PoolWriterBuilder};
 use crate::runtime::yield_now;
 
-const FILE_WRITER_QUEUE_SIZE: usize = 2048;
+pub const FILE_WRITER_QUEUE_SIZE: usize = 2048;
 
 #[derive(Debug, Snafu)]
 pub enum CommandError {
@@ -187,6 +189,7 @@ async fn open_file(path: PathBuf, size: u64) -> Result<File, FileWriterError> {
 pub struct FileWriter {
     pub kind: FileRangeWriterKind,
     inner: Arc<FileRangeWriterImpl>,
+    metrics: FileWriterMetrics,
 }
 
 impl FileWriter {
@@ -201,16 +204,28 @@ impl FileWriter {
         kind: FileRangeWriterKind,
     ) -> Result<Self, FileWriterBuilderError> {
         let path = path.to_path_buf();
+        let metrics = FileWriterMetrics::new();
 
         let inner = match kind {
             #[cfg(feature = "mmap")]
             FileRangeWriterKind::Mmap => {
                 let file = open_file(path.clone(), size).await?;
-                FileRangeWriterImpl::Mmap(MmapWriterBuilder::new().file(file).build().await?)
+                FileRangeWriterImpl::Mmap(
+                    MmapWriterBuilder::new()
+                        .file(file)
+                        .metrics(metrics.clone())
+                        .build()
+                        .await?,
+                )
             }
             FileRangeWriterKind::Pool => {
                 let file = open_file(path.clone(), size).await?;
-                FileRangeWriterImpl::Pool(PoolWriterBuilder::new().file(file).build()?)
+                FileRangeWriterImpl::Pool(
+                    PoolWriterBuilder::new()
+                        .file(file)
+                        .metrics(metrics.clone())
+                        .build()?,
+                )
             }
             FileRangeWriterKind::Null => {
                 // For null writer, we don't need a file - just create the writer
@@ -222,6 +237,7 @@ impl FileWriter {
                 FileRangeWriterImpl::Compio(
                     CompioWriterBuilder::new()
                         .path(path.clone())
+                        .metrics(metrics.clone())
                         .build()
                         .await?,
                 )
@@ -230,6 +246,7 @@ impl FileWriter {
         Ok(Self {
             kind,
             inner: Arc::new(inner),
+            metrics,
         })
     }
 }
@@ -241,6 +258,18 @@ impl FileRangeWriter for FileWriter {
 
     async fn finalize(self) -> Result<(), FileWriterError> {
         self.inner.finalize().await
+    }
+}
+
+impl FileWriter {
+    /// Get the current metrics for this file writer
+    pub fn get_metrics(&self) -> &FileWriterMetrics {
+        &self.metrics
+    }
+
+    /// Get a snapshot of current metrics
+    pub fn get_metrics_snapshot(&self) -> MetricsSnapshot {
+        self.metrics.snapshot()
     }
 }
 

--- a/crates/bolt-load/src/task/instance/concurrent_task/file_writer/compio.rs
+++ b/crates/bolt-load/src/task/instance/concurrent_task/file_writer/compio.rs
@@ -7,8 +7,9 @@ use compio::{BufResult, fs::OpenOptions, io::AsyncWriteAt, runtime::Runtime};
 use snafu::prelude::*;
 
 use super::{
-    Chunk, CommandError, FileRangeWriter, FileWriterBuilderError, FileWriterCapability,
-    FileWriterError, FinalizeSnafu, OpenOrCreateFileSnafu, ValidationSnafu, WriteRangeSnafu,
+    metrics::FileWriterMetrics, Chunk, CommandError, FileRangeWriter, FileWriterBuilderError,
+    FileWriterCapability, FileWriterError, FinalizeSnafu, OpenOrCreateFileSnafu, ValidationSnafu,
+    WriteRangeSnafu,
 };
 
 enum Command {
@@ -19,12 +20,21 @@ enum Command {
 pub struct CompioWriter {
     path: PathBuf,
     tx: Sender<Command>,
+    metrics: FileWriterMetrics,
 }
 
 impl FileRangeWriter for CompioWriter {
     async fn write_range(&self, range: Range<u64>, data: Bytes) -> Result<(), FileWriterError> {
         let (tx, rx) = oneshot::channel();
-        let chunk = Chunk { range, data };
+        let chunk = Chunk {
+            range: range.clone(),
+            data: data.clone(),
+        };
+        let data_len = data.len() as u64;
+
+        // Update queue depth before sending
+        self.metrics.set_queue_depth(self.tx.len());
+
         self.tx
             .send(Command::Write(chunk.clone(), tx))
             .await
@@ -38,6 +48,8 @@ impl FileRangeWriter for CompioWriter {
                     path: self.path.clone(),
                 }
             })?;
+
+        // Wait for write to complete
         rx.await
             .map_err(|_| CommandError::Recv)
             .with_context(|_| WriteRangeSnafu {
@@ -49,6 +61,10 @@ impl FileRangeWriter for CompioWriter {
                 chunk: Some(chunk),
                 path: self.path.clone(),
             })?;
+
+        // Update bytes written after successful write
+        self.metrics.add_bytes_written(data_len);
+
         Ok(())
     }
     async fn finalize(self) -> Result<(), FileWriterError> {
@@ -140,6 +156,7 @@ fn compio_file_writer_task(
 #[derive(Default)]
 pub struct CompioWriterBuilder {
     path: Option<PathBuf>,
+    metrics: Option<FileWriterMetrics>,
 }
 
 impl FileWriterCapability for CompioWriterBuilder {}
@@ -154,6 +171,11 @@ impl CompioWriterBuilder {
         self
     }
 
+    pub fn metrics(mut self, metrics: FileWriterMetrics) -> Self {
+        self.metrics = Some(metrics);
+        self
+    }
+
     pub async fn build(self) -> Result<CompioWriter, FileWriterBuilderError> {
         let Some(path) = self.path else {
             return ValidationSnafu {
@@ -161,6 +183,7 @@ impl CompioWriterBuilder {
             }
             .fail();
         };
+        let metrics = self.metrics.unwrap_or_default();
         let (tx, rx) = async_channel::bounded::<Command>(super::FILE_WRITER_QUEUE_SIZE);
         let (ready_tx, ready_rx) = oneshot::channel();
         let path_clone = path.clone();
@@ -174,6 +197,7 @@ impl CompioWriterBuilder {
         Ok(CompioWriter {
             path,
             tx: tx.clone(),
+            metrics,
         })
     }
 }

--- a/crates/bolt-load/src/task/instance/concurrent_task/file_writer/metrics.rs
+++ b/crates/bolt-load/src/task/instance/concurrent_task/file_writer/metrics.rs
@@ -1,0 +1,186 @@
+//! File writer metrics for monitoring and backpressure control
+
+use std::{
+    sync::{
+        atomic::{AtomicU64, AtomicUsize, Ordering},
+        Arc, Mutex,
+    },
+    time::Instant,
+};
+
+/// Metrics for monitoring file writer performance and queue depth
+#[derive(Clone, Debug)]
+pub struct FileWriterMetrics {
+    /// Current depth of the write command queue
+    queue_depth: Arc<AtomicUsize>,
+    /// Total bytes written since creation
+    bytes_written: Arc<AtomicU64>,
+    /// Bytes written at last sample time
+    last_sample_bytes: Arc<AtomicU64>,
+    /// Last sample timestamp
+    last_sample_time: Arc<Mutex<Instant>>,
+}
+
+impl FileWriterMetrics {
+    /// Create a new metrics instance
+    pub fn new() -> Self {
+        Self {
+            queue_depth: Arc::new(AtomicUsize::new(0)),
+            bytes_written: Arc::new(AtomicU64::new(0)),
+            last_sample_bytes: Arc::new(AtomicU64::new(0)),
+            last_sample_time: Arc::new(Mutex::new(Instant::now())),
+        }
+    }
+
+    /// Get the current queue depth
+    #[inline]
+    pub fn get_queue_depth(&self) -> usize {
+        self.queue_depth.load(Ordering::Relaxed)
+    }
+
+    /// Set the current queue depth
+    #[inline]
+    pub fn set_queue_depth(&self, depth: usize) {
+        self.queue_depth.store(depth, Ordering::Relaxed);
+    }
+
+    /// Increment bytes written counter
+    #[inline]
+    pub fn add_bytes_written(&self, bytes: u64) {
+        self.bytes_written.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    /// Get total bytes written
+    #[inline]
+    pub fn get_total_bytes_written(&self) -> u64 {
+        self.bytes_written.load(Ordering::Relaxed)
+    }
+
+    /// Calculate current write speed (bytes/sec)
+    ///
+    /// Returns the write speed since last sample and updates the sample timestamp
+    pub fn sample_write_speed(&self) -> f64 {
+        let current_bytes = self.get_total_bytes_written();
+        let mut last_time = self.last_sample_time.lock().unwrap();
+        let now = Instant::now();
+        let elapsed = now.duration_since(*last_time).as_secs_f64();
+
+        // Avoid division by zero
+        if elapsed < 0.001 {
+            return 0.0;
+        }
+
+        let last_bytes = self.last_sample_bytes.load(Ordering::Relaxed);
+        let bytes_delta = current_bytes.saturating_sub(last_bytes);
+        let speed = bytes_delta as f64 / elapsed;
+
+        // Update for next sample
+        self.last_sample_bytes.store(current_bytes, Ordering::Relaxed);
+        *last_time = now;
+
+        speed
+    }
+
+    /// Get a snapshot of current metrics
+    pub fn snapshot(&self) -> MetricsSnapshot {
+        MetricsSnapshot {
+            queue_depth: self.get_queue_depth(),
+            total_bytes_written: self.get_total_bytes_written(),
+            write_speed: self.sample_write_speed(),
+        }
+    }
+}
+
+impl Default for FileWriterMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A point-in-time snapshot of file writer metrics
+#[derive(Debug, Clone, Copy)]
+pub struct MetricsSnapshot {
+    /// Current queue depth
+    pub queue_depth: usize,
+    /// Total bytes written
+    pub total_bytes_written: u64,
+    /// Current write speed in bytes/sec
+    pub write_speed: f64,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{thread, time::Duration};
+
+    use super::*;
+
+    #[test]
+    fn test_metrics_new() {
+        let metrics = FileWriterMetrics::new();
+        assert_eq!(metrics.get_queue_depth(), 0);
+        assert_eq!(metrics.get_total_bytes_written(), 0);
+    }
+
+    #[test]
+    fn test_queue_depth() {
+        let metrics = FileWriterMetrics::new();
+        metrics.set_queue_depth(10);
+        assert_eq!(metrics.get_queue_depth(), 10);
+
+        metrics.set_queue_depth(42);
+        assert_eq!(metrics.get_queue_depth(), 42);
+    }
+
+    #[test]
+    fn test_bytes_written() {
+        let metrics = FileWriterMetrics::new();
+        metrics.add_bytes_written(100);
+        assert_eq!(metrics.get_total_bytes_written(), 100);
+
+        metrics.add_bytes_written(50);
+        assert_eq!(metrics.get_total_bytes_written(), 150);
+    }
+
+    #[test]
+    fn test_write_speed() {
+        let metrics = FileWriterMetrics::new();
+
+        // Initial speed should be 0
+        let speed1 = metrics.sample_write_speed();
+        assert_eq!(speed1, 0.0);
+
+        // Write some bytes and wait a bit
+        metrics.add_bytes_written(1000);
+        thread::sleep(Duration::from_millis(100));
+
+        let speed2 = metrics.sample_write_speed();
+        // Speed should be approximately 10000 bytes/sec (1000 bytes / 0.1 sec)
+        assert!(speed2 > 5000.0 && speed2 < 15000.0);
+    }
+
+    #[test]
+    fn test_snapshot() {
+        let metrics = FileWriterMetrics::new();
+        metrics.set_queue_depth(5);
+        metrics.add_bytes_written(200);
+
+        let snapshot = metrics.snapshot();
+        assert_eq!(snapshot.queue_depth, 5);
+        assert_eq!(snapshot.total_bytes_written, 200);
+    }
+
+    #[test]
+    fn test_metrics_clone() {
+        let metrics1 = FileWriterMetrics::new();
+        metrics1.set_queue_depth(7);
+        metrics1.add_bytes_written(300);
+
+        let metrics2 = metrics1.clone();
+        assert_eq!(metrics2.get_queue_depth(), 7);
+        assert_eq!(metrics2.get_total_bytes_written(), 300);
+
+        // Both should share the same underlying data
+        metrics1.set_queue_depth(15);
+        assert_eq!(metrics2.get_queue_depth(), 15);
+    }
+}

--- a/crates/bolt-load/src/task/instance/concurrent_task/file_writer/mmap.rs
+++ b/crates/bolt-load/src/task/instance/concurrent_task/file_writer/mmap.rs
@@ -9,13 +9,15 @@ use memmap2::MmapMut;
 use snafu::prelude::*;
 
 use super::{
-    Chunk, CommandError, FileRangeWriter, FileWriterBuilderError, FileWriterCapability,
-    FileWriterError, FinalizeSnafu, OpenOrCreateFileSnafu, ValidationSnafu, WriteRangeSnafu,
+    metrics::FileWriterMetrics, Chunk, CommandError, FileRangeWriter, FileWriterBuilderError,
+    FileWriterCapability, FileWriterError, FinalizeSnafu, OpenOrCreateFileSnafu, ValidationSnafu,
+    WriteRangeSnafu,
 };
 
 pub struct MmapWriter {
     pub file: File,
     tx: Sender<Command>,
+    metrics: FileWriterMetrics,
 }
 
 impl FileRangeWriter for MmapWriter {
@@ -42,7 +44,15 @@ impl FileRangeWriter for MmapWriter {
 
     async fn write_range(&self, range: Range<u64>, data: Bytes) -> Result<(), FileWriterError> {
         let (tx, rx) = oneshot::channel();
-        let chunk = Chunk { range, data };
+        let chunk = Chunk {
+            range: range.clone(),
+            data: data.clone(),
+        };
+        let data_len = data.len() as u64;
+
+        // Update queue depth before sending
+        self.metrics.set_queue_depth(self.tx.len());
+
         self.tx
             .send(Command::Write(chunk.clone(), tx))
             .await
@@ -56,6 +66,8 @@ impl FileRangeWriter for MmapWriter {
                     path: self.file.path().to_path_buf(),
                 }
             })?;
+
+        // Wait for write to complete
         rx.await
             .map_err(|_| CommandError::Recv)
             .with_context(|_| WriteRangeSnafu {
@@ -67,6 +79,10 @@ impl FileRangeWriter for MmapWriter {
                 chunk: Some(chunk),
                 path: self.file.path().to_path_buf(),
             })?;
+
+        // Update bytes written after successful write
+        self.metrics.add_bytes_written(data_len);
+
         Ok(())
     }
 }
@@ -79,6 +95,7 @@ enum Command {
 #[derive(Default)]
 pub struct MmapWriterBuilder {
     pub file: Option<File>,
+    pub metrics: Option<FileWriterMetrics>,
 }
 
 impl FileWriterCapability for MmapWriterBuilder {
@@ -171,6 +188,11 @@ impl MmapWriterBuilder {
         self
     }
 
+    pub fn metrics(mut self, metrics: FileWriterMetrics) -> Self {
+        self.metrics = Some(metrics);
+        self
+    }
+
     pub async fn build(self) -> Result<MmapWriter, FileWriterBuilderError> {
         let Some(file) = self.file else {
             return Err(ValidationSnafu {
@@ -179,6 +201,7 @@ impl MmapWriterBuilder {
             .build());
         };
 
+        let metrics = self.metrics.unwrap_or_default();
         let (chunk_tx, chunk_rx) = async_channel::bounded::<Command>(super::FILE_WRITER_QUEUE_SIZE);
         let (ready_tx, ready_rx) = oneshot::channel();
         let file_clone = file
@@ -199,7 +222,11 @@ impl MmapWriterBuilder {
             .with_context(|_| OpenOrCreateFileSnafu {
                 path: file.path().to_path_buf(),
             })?;
-        Ok(MmapWriter { file, tx: chunk_tx })
+        Ok(MmapWriter {
+            file,
+            tx: chunk_tx,
+            metrics,
+        })
     }
 }
 

--- a/crates/bolt-load/src/task/instance/concurrent_task/file_writer/pool.rs
+++ b/crates/bolt-load/src/task/instance/concurrent_task/file_writer/pool.rs
@@ -7,13 +7,15 @@ use fs_err as fs;
 use snafu::prelude::*;
 
 use super::{
-    Chunk, CommandError, FileRangeWriter, FileWriterBuilderError, FileWriterCapability,
-    FileWriterError, FinalizeSnafu, OpenOrCreateFileSnafu, ValidationSnafu, WriteRangeSnafu,
+    metrics::FileWriterMetrics, Chunk, CommandError, FileRangeWriter, FileWriterBuilderError,
+    FileWriterCapability, FileWriterError, FinalizeSnafu, OpenOrCreateFileSnafu, ValidationSnafu,
+    WriteRangeSnafu,
 };
 
 pub struct PoolWriter {
     pub file: File,
     tx: Sender<Command>,
+    metrics: FileWriterMetrics,
 }
 
 enum Command {
@@ -46,7 +48,15 @@ impl FileRangeWriter for PoolWriter {
 
     async fn write_range(&self, range: Range<u64>, data: Bytes) -> Result<(), FileWriterError> {
         let (tx, rx) = oneshot::channel();
-        let chunk = Chunk { range, data };
+        let chunk = Chunk {
+            range: range.clone(),
+            data: data.clone(),
+        };
+        let data_len = data.len() as u64;
+
+        // Update queue depth before sending
+        self.metrics.set_queue_depth(self.tx.len());
+
         self.tx
             .send(Command::Write(chunk.clone(), tx))
             .await
@@ -60,6 +70,8 @@ impl FileRangeWriter for PoolWriter {
                     path: self.file.path().to_path_buf(),
                 }
             })?;
+
+        // Wait for write to complete
         rx.await
             .map_err(|_| CommandError::Recv)
             .with_context(|_| WriteRangeSnafu {
@@ -71,6 +83,10 @@ impl FileRangeWriter for PoolWriter {
                 chunk: Some(chunk),
                 path: self.file.path().to_path_buf(),
             })?;
+
+        // Update bytes written after successful write
+        self.metrics.add_bytes_written(data_len);
+
         Ok(())
     }
 }
@@ -79,6 +95,7 @@ impl FileRangeWriter for PoolWriter {
 pub struct PoolWriterBuilder {
     pub file: Option<File>,
     pub parallel: Option<usize>,
+    pub metrics: Option<FileWriterMetrics>,
 }
 
 impl FileWriterCapability for PoolWriterBuilder {}
@@ -132,6 +149,11 @@ impl PoolWriterBuilder {
         self
     }
 
+    pub fn metrics(mut self, metrics: FileWriterMetrics) -> Self {
+        self.metrics = Some(metrics);
+        self
+    }
+
     pub fn build(self) -> Result<PoolWriter, FileWriterBuilderError> {
         let Some(file) = self.file else {
             return ValidationSnafu {
@@ -142,6 +164,7 @@ impl PoolWriterBuilder {
         let parallel = self
             .parallel
             .unwrap_or(std::thread::available_parallelism().unwrap().get());
+        let metrics = self.metrics.unwrap_or_default();
         let (tx, rx) = async_channel::bounded::<Command>(super::FILE_WRITER_QUEUE_SIZE);
         for _ in 0..parallel {
             let file = file
@@ -156,6 +179,7 @@ impl PoolWriterBuilder {
         Ok(PoolWriter {
             file,
             tx: tx.clone(),
+            metrics,
         })
     }
 }

--- a/crates/bolt-load/src/task/instance/concurrent_task/file_writer/write_budget.rs
+++ b/crates/bolt-load/src/task/instance/concurrent_task/file_writer/write_budget.rs
@@ -1,0 +1,303 @@
+//! Write budget mechanism for backpressure control at the runner level
+//!
+//! Instead of controlling concurrency, this directly throttles data reading from
+//! the stream by requiring budget tokens before consuming data. This prevents
+//! excessive memory buildup when disk I/O is slower than network download.
+
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+use async_notify::Notify;
+use bolt_load_utils::telemetry::*;
+
+/// Default budget capacity: 32 MB
+/// This allows ~16 concurrent 2MB chunks to be in-flight
+const DEFAULT_BUDGET_CAPACITY: usize = 32 * 1024 * 1024;
+
+/// High watermark threshold (75% of capacity)
+/// When available budget crosses this threshold during refill, wake waiters
+const DEFAULT_HIGH_WATERMARK_RATIO: f64 = 0.75;
+
+/// Write budget for controlling data flow from runners to file writer
+///
+/// This mechanism ensures that runners don't download data faster than
+/// the file writer can write it to disk, preventing memory exhaustion.
+#[derive(Clone)]
+pub struct WriteBudget {
+    /// Current available budget (in bytes)
+    available: Arc<AtomicUsize>,
+    /// Notifier for waking waiting runners
+    notifier: Arc<Notify>,
+    /// Total budget capacity
+    capacity: usize,
+    /// High watermark for triggering notifications
+    high_watermark: usize,
+}
+
+impl WriteBudget {
+    /// Create a new write budget with default capacity (32 MB)
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_BUDGET_CAPACITY)
+    }
+
+    /// Create a new write budget with custom capacity
+    pub fn with_capacity(capacity: usize) -> Self {
+        let high_watermark = (capacity as f64 * DEFAULT_HIGH_WATERMARK_RATIO) as usize;
+        Self {
+            available: Arc::new(AtomicUsize::new(capacity)),
+            notifier: Arc::new(Notify::new()),
+            capacity,
+            high_watermark,
+        }
+    }
+
+    /// Get the current available budget
+    pub fn available(&self) -> usize {
+        self.available.load(Ordering::Acquire)
+    }
+
+    /// Get the total capacity
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+
+    /// Acquire budget, waiting if necessary
+    ///
+    /// This will block until sufficient budget is available and consume it.
+    /// The budget should be refilled manually by calling `refill()` after the write completes.
+    pub async fn acquire(&self, size: usize) {
+        // Fast path: try immediate acquisition
+        if self.try_consume(size) {
+            return;
+        }
+
+        // Slow path: wait for budget to become available
+        loop {
+            // Wait for notification
+            let notified = self.notifier.notified();
+
+            // Double-check after creating the future but before awaiting
+            if self.try_consume(size) {
+                return;
+            }
+
+            // Wait for refill notification
+            notified.await;
+
+            // Try to acquire after being notified
+            if self.try_consume(size) {
+                return;
+            }
+        }
+    }
+
+    /// Try to consume budget without waiting
+    ///
+    /// Returns `true` if budget was consumed, `false` otherwise
+    fn try_consume(&self, size: usize) -> bool {
+        loop {
+            let current = self.available.load(Ordering::Acquire);
+            if current < size {
+                return false;
+            }
+
+            // Try to consume budget using compare-exchange
+            match self.available.compare_exchange_weak(
+                current,
+                current - size,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    trace!(
+                        "[BUDGET] Consumed {} bytes, available: {} -> {}",
+                        size,
+                        current,
+                        current - size
+                    );
+                    return true;
+                }
+                Err(_) => {
+                    // CAS failed due to concurrent modification, retry
+                    continue;
+                }
+            }
+        }
+    }
+
+    /// Refill budget (called by file writer after successful write)
+    ///
+    /// This increases the available budget and notifies waiting runners
+    /// if the budget crosses the high watermark threshold.
+    pub fn refill(&self, amount: usize) {
+        let prev = self.available.fetch_add(amount, Ordering::Release);
+        let new = prev + amount;
+
+        // Cap at capacity
+        if new > self.capacity {
+            let excess = new - self.capacity;
+            self.available.fetch_sub(excess, Ordering::Release);
+            trace!(
+                "[BUDGET] Refilled {} bytes (capped excess: {}), available: {} -> {}",
+                amount,
+                excess,
+                prev,
+                self.capacity
+            );
+        } else {
+            trace!(
+                "[BUDGET] Refilled {} bytes, available: {} -> {}",
+                amount,
+                prev,
+                new
+            );
+        }
+
+        // Notify waiters if we crossed the high watermark
+        // Note: notify() wakes up one waiter, and they will re-check budget
+        // and potentially wake up others if budget is still sufficient
+        if prev < self.high_watermark && new >= self.high_watermark {
+            trace!("[BUDGET] Crossed high watermark, notifying waiters");
+            self.notifier.notify();
+        }
+    }
+}
+
+impl Default for WriteBudget {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+
+impl std::fmt::Debug for WriteBudget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WriteBudget")
+            .field("available", &self.available())
+            .field("capacity", &self.capacity)
+            .field("high_watermark", &self.high_watermark)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_budget_new() {
+        let budget = WriteBudget::new();
+        assert_eq!(budget.available(), DEFAULT_BUDGET_CAPACITY);
+        assert_eq!(budget.capacity(), DEFAULT_BUDGET_CAPACITY);
+    }
+
+    #[test]
+    fn test_budget_with_capacity() {
+        let budget = WriteBudget::with_capacity(1024);
+        assert_eq!(budget.available(), 1024);
+        assert_eq!(budget.capacity(), 1024);
+    }
+
+    #[test]
+    fn test_try_consume_success() {
+        let budget = WriteBudget::with_capacity(1000);
+        assert!(budget.try_consume(100));
+        assert_eq!(budget.available(), 900);
+    }
+
+    #[test]
+    fn test_try_consume_failure() {
+        let budget = WriteBudget::with_capacity(100);
+        assert!(!budget.try_consume(200));
+        assert_eq!(budget.available(), 100);
+    }
+
+    #[test]
+    fn test_refill() {
+        let budget = WriteBudget::with_capacity(1000);
+        budget.try_consume(300);
+        assert_eq!(budget.available(), 700);
+
+        budget.refill(300);
+        assert_eq!(budget.available(), 1000);
+    }
+
+    #[test]
+    fn test_refill_caps_at_capacity() {
+        let budget = WriteBudget::with_capacity(1000);
+        budget.refill(500); // Already at 1000, so this should be capped
+        assert_eq!(budget.available(), 1000);
+    }
+
+    #[tokio::test]
+    async fn test_acquire_immediate() {
+        let budget = WriteBudget::with_capacity(1000);
+        budget.acquire(100).await;
+        assert_eq!(budget.available(), 900);
+
+        // Manually refill
+        budget.refill(100);
+        assert_eq!(budget.available(), 1000);
+    }
+
+    #[tokio::test]
+    async fn test_acquire_waits_for_budget() {
+        let budget = WriteBudget::with_capacity(100);
+
+        // Consume all budget
+        budget.acquire(100).await;
+        assert_eq!(budget.available(), 0);
+
+        // Spawn a task that will wait for budget
+        let budget_clone = budget.clone();
+        let task = tokio::spawn(async move {
+            budget_clone.acquire(50).await;
+        });
+
+        // Give the task time to start waiting
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+
+        // Refill budget
+        budget.refill(100);
+
+        // The waiting task should now complete
+        task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_acquisitions() {
+        let budget = WriteBudget::with_capacity(1000);
+
+        let mut tasks = vec![];
+        for _ in 0..10 {
+            let budget_clone = budget.clone();
+            tasks.push(tokio::spawn(async move {
+                budget_clone.acquire(100).await;
+                // Simulate some work
+                tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+                // Manually refill after "work" completes
+                budget_clone.refill(100);
+            }));
+        }
+
+        // All tasks should complete successfully
+        for task in tasks {
+            task.await.unwrap();
+        }
+
+        // Budget should be fully refilled after all tasks complete
+        assert_eq!(budget.available(), 1000);
+    }
+
+    #[test]
+    fn test_debug_format() {
+        let budget = WriteBudget::with_capacity(2048);
+        let debug_str = format!("{:?}", budget);
+        assert!(debug_str.contains("WriteBudget"));
+        assert!(debug_str.contains("available"));
+        assert!(debug_str.contains("capacity"));
+    }
+}

--- a/crates/bolt-load/src/task/instance/concurrent_task/mod.rs
+++ b/crates/bolt-load/src/task/instance/concurrent_task/mod.rs
@@ -502,12 +502,19 @@ impl ConcurrentTaskInner {
 
         current_speed: f64,
         per_runner_avg_speed: f64,
+        file_writer: &FileWriter,
     ) -> Result<()> {
+        // Sample write metrics
+        let write_queue_depth = file_writer.get_metrics().get_queue_depth();
+        let write_speed = file_writer.get_metrics().sample_write_speed();
+
         if let Some((strategy_name, actions)) = strategy_control.execute(
             *max_concurrency,
             current_speed,
             per_runner_avg_speed,
             runner_manager,
+            write_queue_depth,
+            write_speed,
         ) {
             for action in actions {
                 trace!("[TASK] applying strategy: {strategy_name}, action: {action:?}");
@@ -579,6 +586,7 @@ impl ConcurrentTaskInner {
 
                             current_speed,
                             per_runner_avg_speed,
+                            &file_writer,
                         ).await.inspect_err(|e| {
                             error!("failed to download strategy timer tick: {e:?}");
                             self.sync_progress(&runner_manager);

--- a/crates/bolt-load/src/task/instance/concurrent_task/strategy/mod.rs
+++ b/crates/bolt-load/src/task/instance/concurrent_task/strategy/mod.rs
@@ -5,10 +5,13 @@ use bolt_load_utils::telemetry::*;
 mod concurrency_control_strategy;
 mod dynamic_strategy;
 mod runner_outcome_sampler;
+mod write_backpressure_strategy;
 
 use concurrency_control_strategy::{ConcurrencyControlContext, ConcurrencyControlStrategy};
 use dynamic_strategy::{DynamicStrategy, DynamicStrategyContext};
 pub use runner_outcome_sampler::{FailureKind as RunnerFailureKind, RunnerOutcomeSampler};
+use write_backpressure_strategy::{WriteBackpressureContext, WriteBackpressureStrategy};
+pub use write_backpressure_strategy::WriteBackpressureConfig;
 
 pub const DEFAULT_STRATEGY_TICK_INTERVAL: Duration = Duration::from_millis(1500); // 1.5 seconds
 
@@ -39,6 +42,7 @@ pub trait Strategy {
 pub struct StrategyControl {
     dynamic_strategy: DynamicStrategy,
     concurrency_control_strategy: ConcurrencyControlStrategy,
+    write_backpressure_strategy: WriteBackpressureStrategy,
 }
 
 impl StrategyControl {
@@ -48,6 +52,7 @@ impl StrategyControl {
             concurrency_control_strategy: ConcurrencyControlStrategy::with_default_config(
                 initial_max_concurrency,
             ),
+            write_backpressure_strategy: WriteBackpressureStrategy::with_default_config(),
         }
     }
 
@@ -57,8 +62,26 @@ impl StrategyControl {
         current_speed: f64,
         per_runner_avg_speed: f64,
         runner_manager: &mut super::RunnerManager,
+        write_queue_depth: usize,
+        write_speed: f64,
     ) -> Option<(&'static str, Vec<StrategyAction>)> {
+        // Priority 1: Check write backpressure first (highest priority)
         let active_runners = runner_manager.get_active_runners_count();
+        let mut write_context = WriteBackpressureContext {
+            queue_depth: write_queue_depth,
+            write_speed,
+            download_speed: current_speed,
+            current_concurrency: active_runners,
+            max_concurrency,
+        };
+        trace!("[STRATEGY] Write backpressure strategy context: {write_context:?}");
+        let actions = self.write_backpressure_strategy.step(&mut write_context);
+
+        if !actions.is_empty() {
+            return Some((WriteBackpressureStrategy::name(), actions));
+        }
+
+        // Priority 2: Concurrency control based on failure rate
         let available_chunks = runner_manager.get_available_ranges();
         let mut context = ConcurrencyControlContext {
             max_concurrency,

--- a/crates/bolt-load/src/task/instance/concurrent_task/strategy/write_backpressure_strategy.rs
+++ b/crates/bolt-load/src/task/instance/concurrent_task/strategy/write_backpressure_strategy.rs
@@ -1,0 +1,355 @@
+//! Write backpressure strategy to prevent memory exhaustion from slow disk I/O
+//!
+//! This strategy monitors the file writer queue depth and write speed,
+//! dynamically adjusting concurrency to prevent excessive memory usage.
+
+use std::time::{Duration, Instant};
+
+use bolt_load_utils::telemetry::*;
+
+use super::{Strategy, StrategyAction};
+use crate::task::instance::concurrent_task::file_writer::FILE_WRITER_QUEUE_SIZE;
+
+/// Queue depth thresholds as percentage of FILE_WRITER_QUEUE_SIZE (2048)
+const QUEUE_DEPTH_HIGH_THRESHOLD: f64 = 0.75; // 1536 items
+const QUEUE_DEPTH_CRITICAL_THRESHOLD: f64 = 0.90; // 1843 items
+
+/// Write speed ratio threshold (write_speed / download_speed)
+const WRITE_SPEED_RATIO_THRESHOLD: f64 = 0.5; // Write speed < 50% of download speed
+
+/// Minimum time between backpressure actions to avoid thrashing
+const MIN_ACTION_INTERVAL: Duration = Duration::from_secs(3);
+
+/// Configuration for write backpressure control
+#[derive(Debug, Clone)]
+pub struct WriteBackpressureConfig {
+    /// High queue depth threshold (as percentage of max queue size)
+    pub queue_depth_high_threshold: f64,
+    /// Critical queue depth threshold (as percentage of max queue size)
+    pub queue_depth_critical_threshold: f64,
+    /// Write/download speed ratio threshold
+    pub write_speed_ratio_threshold: f64,
+    /// Minimum interval between actions
+    pub min_action_interval: Duration,
+    /// Degradation step (how many runners to reduce)
+    pub degradation_step: usize,
+    /// Minimum concurrency to maintain
+    pub min_concurrency: usize,
+}
+
+impl Default for WriteBackpressureConfig {
+    fn default() -> Self {
+        Self {
+            queue_depth_high_threshold: QUEUE_DEPTH_HIGH_THRESHOLD,
+            queue_depth_critical_threshold: QUEUE_DEPTH_CRITICAL_THRESHOLD,
+            write_speed_ratio_threshold: WRITE_SPEED_RATIO_THRESHOLD,
+            min_action_interval: MIN_ACTION_INTERVAL,
+            degradation_step: 1,
+            min_concurrency: 1,
+        }
+    }
+}
+
+/// Backpressure state
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BackpressureState {
+    /// Normal operation
+    Normal,
+    /// High queue depth detected
+    High,
+    /// Critical queue depth - immediate action required
+    Critical,
+}
+
+/// Write backpressure strategy context
+#[derive(Debug)]
+pub struct WriteBackpressureContext {
+    /// Current queue depth
+    pub queue_depth: usize,
+    /// Write speed (bytes/sec)
+    pub write_speed: f64,
+    /// Download speed (bytes/sec)
+    pub download_speed: f64,
+    /// Current active concurrency
+    pub current_concurrency: usize,
+    /// Maximum allowed concurrency
+    pub max_concurrency: usize,
+}
+
+/// Write backpressure control strategy
+pub struct WriteBackpressureStrategy {
+    config: WriteBackpressureConfig,
+    state: BackpressureState,
+    last_action_time: Option<Instant>,
+}
+
+impl WriteBackpressureStrategy {
+    /// Create a new write backpressure strategy with default config
+    pub fn with_default_config() -> Self {
+        Self {
+            config: WriteBackpressureConfig::default(),
+            state: BackpressureState::Normal,
+            last_action_time: None,
+        }
+    }
+
+    /// Create a new write backpressure strategy with custom config
+    pub fn with_config(config: WriteBackpressureConfig) -> Self {
+        Self {
+            config,
+            state: BackpressureState::Normal,
+            last_action_time: None,
+        }
+    }
+
+    /// Determine the current backpressure state based on queue depth
+    fn determine_state(&self, queue_depth: usize) -> BackpressureState {
+        let queue_depth_ratio = queue_depth as f64 / FILE_WRITER_QUEUE_SIZE as f64;
+
+        if queue_depth_ratio >= self.config.queue_depth_critical_threshold {
+            BackpressureState::Critical
+        } else if queue_depth_ratio >= self.config.queue_depth_high_threshold {
+            BackpressureState::High
+        } else {
+            BackpressureState::Normal
+        }
+    }
+
+    /// Check if we should take action based on time throttling
+    fn should_take_action(&self) -> bool {
+        match self.last_action_time {
+            None => true,
+            Some(last_time) => last_time.elapsed() >= self.config.min_action_interval,
+        }
+    }
+
+    /// Calculate the new concurrency level
+    fn calculate_new_concurrency(
+        &self,
+        current: usize,
+        state: BackpressureState,
+    ) -> Option<usize> {
+        match state {
+            BackpressureState::Critical => {
+                // Reduce by 25% or degradation_step, whichever is larger
+                let reduction = std::cmp::max(current / 4, self.config.degradation_step);
+                let new_concurrency = current.saturating_sub(reduction);
+                Some(std::cmp::max(new_concurrency, self.config.min_concurrency))
+            }
+            BackpressureState::High => {
+                // Gradual reduction
+                let new_concurrency = current.saturating_sub(self.config.degradation_step);
+                Some(std::cmp::max(new_concurrency, self.config.min_concurrency))
+            }
+            BackpressureState::Normal => None,
+        }
+    }
+}
+
+impl Strategy for WriteBackpressureStrategy {
+    type Context<'a> = WriteBackpressureContext;
+
+    fn name() -> &'static str {
+        "WriteBackpressure"
+    }
+
+    fn step(&mut self, context: &mut Self::Context<'_>) -> Vec<StrategyAction> {
+        let new_state = self.determine_state(context.queue_depth);
+
+        trace!(
+            "[STRATEGY] Write backpressure check: queue_depth={}/{}, write_speed={:.2} MB/s, download_speed={:.2} MB/s, state={:?}",
+            context.queue_depth,
+            FILE_WRITER_QUEUE_SIZE,
+            context.write_speed / 1024.0 / 1024.0,
+            context.download_speed / 1024.0 / 1024.0,
+            new_state
+        );
+
+        // Update state
+        let prev_state = self.state;
+        self.state = new_state;
+
+        // Check if we need to take action
+        let mut actions = Vec::new();
+
+        match new_state {
+            BackpressureState::Critical => {
+                // Critical state: always take action immediately
+                if let Some(new_concurrency) =
+                    self.calculate_new_concurrency(context.current_concurrency, new_state)
+                {
+                    if new_concurrency < context.current_concurrency {
+                        warn!(
+                            "[STRATEGY] CRITICAL write backpressure detected! Queue depth: {}/{} ({:.1}%), reducing concurrency {} -> {}",
+                            context.queue_depth,
+                            FILE_WRITER_QUEUE_SIZE,
+                            (context.queue_depth as f64 / FILE_WRITER_QUEUE_SIZE as f64) * 100.0,
+                            context.current_concurrency,
+                            new_concurrency
+                        );
+                        actions.push(StrategyAction::ChangeMaxConcurrency(new_concurrency));
+                        self.last_action_time = Some(Instant::now());
+                    }
+                }
+            }
+            BackpressureState::High => {
+                // High state: take action if write speed is also slow
+                let write_ratio = if context.download_speed > 0.0 {
+                    context.write_speed / context.download_speed
+                } else {
+                    1.0
+                };
+
+                if write_ratio < self.config.write_speed_ratio_threshold && self.should_take_action()
+                {
+                    if let Some(new_concurrency) =
+                        self.calculate_new_concurrency(context.current_concurrency, new_state)
+                    {
+                        if new_concurrency < context.current_concurrency {
+                            info!(
+                                "[STRATEGY] High write backpressure detected! Queue depth: {}/{} ({:.1}%), write/download ratio: {:.2}, reducing concurrency {} -> {}",
+                                context.queue_depth,
+                                FILE_WRITER_QUEUE_SIZE,
+                                (context.queue_depth as f64 / FILE_WRITER_QUEUE_SIZE as f64) * 100.0,
+                                write_ratio,
+                                context.current_concurrency,
+                                new_concurrency
+                            );
+                            actions.push(StrategyAction::ChangeMaxConcurrency(new_concurrency));
+                            self.last_action_time = Some(Instant::now());
+                        }
+                    }
+                }
+            }
+            BackpressureState::Normal => {
+                // Normal state: log recovery if we were in a backpressure state before
+                if prev_state != BackpressureState::Normal {
+                    debug!(
+                        "[STRATEGY] Write backpressure recovered. Queue depth: {}/{} ({:.1}%)",
+                        context.queue_depth,
+                        FILE_WRITER_QUEUE_SIZE,
+                        (context.queue_depth as f64 / FILE_WRITER_QUEUE_SIZE as f64) * 100.0
+                    );
+                }
+            }
+        }
+
+        actions
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_determine_state_normal() {
+        let strategy = WriteBackpressureStrategy::with_default_config();
+        let state = strategy.determine_state(100); // ~5% of 2048
+        assert_eq!(state, BackpressureState::Normal);
+    }
+
+    #[test]
+    fn test_determine_state_high() {
+        let strategy = WriteBackpressureStrategy::with_default_config();
+        let state = strategy.determine_state(1600); // ~78% of 2048
+        assert_eq!(state, BackpressureState::High);
+    }
+
+    #[test]
+    fn test_determine_state_critical() {
+        let strategy = WriteBackpressureStrategy::with_default_config();
+        let state = strategy.determine_state(1900); // ~93% of 2048
+        assert_eq!(state, BackpressureState::Critical);
+    }
+
+    #[test]
+    fn test_calculate_new_concurrency_critical() {
+        let strategy = WriteBackpressureStrategy::with_default_config();
+        let new_concurrency =
+            strategy.calculate_new_concurrency(8, BackpressureState::Critical);
+        assert_eq!(new_concurrency, Some(6)); // 25% reduction: 8 * 0.75 = 6
+    }
+
+    #[test]
+    fn test_calculate_new_concurrency_high() {
+        let strategy = WriteBackpressureStrategy::with_default_config();
+        let new_concurrency = strategy.calculate_new_concurrency(8, BackpressureState::High);
+        assert_eq!(new_concurrency, Some(7)); // degradation_step = 1
+    }
+
+    #[test]
+    fn test_calculate_new_concurrency_min() {
+        let strategy = WriteBackpressureStrategy::with_default_config();
+        let new_concurrency =
+            strategy.calculate_new_concurrency(1, BackpressureState::Critical);
+        assert_eq!(new_concurrency, Some(1)); // Can't go below min_concurrency
+    }
+
+    #[test]
+    fn test_strategy_step_critical() {
+        let mut strategy = WriteBackpressureStrategy::with_default_config();
+        let mut context = WriteBackpressureContext {
+            queue_depth: 1900, // Critical
+            write_speed: 1_000_000.0,
+            download_speed: 10_000_000.0,
+            current_concurrency: 8,
+            max_concurrency: 8,
+        };
+
+        let actions = strategy.step(&mut context);
+        assert!(!actions.is_empty());
+        match &actions[0] {
+            StrategyAction::ChangeMaxConcurrency(new_concurrency) => {
+                assert!(*new_concurrency < 8);
+            }
+            _ => panic!("Expected ChangeMaxConcurrency action"),
+        }
+    }
+
+    #[test]
+    fn test_strategy_step_high_with_slow_write() {
+        let mut strategy = WriteBackpressureStrategy::with_default_config();
+        let mut context = WriteBackpressureContext {
+            queue_depth: 1600,                // High
+            write_speed: 1_000_000.0,         // 1 MB/s
+            download_speed: 10_000_000.0,     // 10 MB/s (ratio = 0.1 < 0.5)
+            current_concurrency: 8,
+            max_concurrency: 8,
+        };
+
+        let actions = strategy.step(&mut context);
+        assert!(!actions.is_empty());
+    }
+
+    #[test]
+    fn test_strategy_step_high_with_fast_write() {
+        let mut strategy = WriteBackpressureStrategy::with_default_config();
+        let mut context = WriteBackpressureContext {
+            queue_depth: 1600,            // High
+            write_speed: 8_000_000.0,     // 8 MB/s
+            download_speed: 10_000_000.0, // 10 MB/s (ratio = 0.8 > 0.5)
+            current_concurrency: 8,
+            max_concurrency: 8,
+        };
+
+        let actions = strategy.step(&mut context);
+        // Should not reduce concurrency because write speed is still good
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn test_strategy_step_normal() {
+        let mut strategy = WriteBackpressureStrategy::with_default_config();
+        let mut context = WriteBackpressureContext {
+            queue_depth: 100, // Normal
+            write_speed: 5_000_000.0,
+            download_speed: 10_000_000.0,
+            current_concurrency: 8,
+            max_concurrency: 8,
+        };
+
+        let actions = strategy.step(&mut context);
+        assert!(actions.is_empty());
+    }
+}


### PR DESCRIPTION
Implement comprehensive throttling to prevent memory exhaustion caused by slow disk I/O speeds overwhelming the download pipeline.

## Changes

1. **FileWriterMetrics** - New sampling infrastructure:
   - Track queue depth, bytes written, and write speed
   - Use Atomic operations for lock-free metrics collection
   - Sample write speed at strategy tick intervals

2. **WriteBackpressureStrategy** - Intelligent backpressure control:
   - Monitor queue depth (75% HIGH, 90% CRITICAL thresholds)
   - Compare write speed vs download speed (50% ratio threshold)
   - Dynamically reduce concurrency when backpressure detected
   - Prioritized over failure-rate concurrency control

3. **Integration**:
   - Metrics embedded in all FileWriter implementations (Pool, Compio, Mmap)
   - Strategy integrated into StrategyControl with highest priority
   - Event loop samples metrics every 1.5s via strategy timer

## Implementation Details

- Uses **Atomic + Notifier** approach (not governor) for dynamic adjustment
- Queue depth thresholds: 1536/2048 (HIGH), 1843/2048 (CRITICAL)
- CRITICAL state triggers immediate 25% concurrency reduction
- HIGH state with slow write (< 50% download speed) triggers gradual reduction
- Minimum 3-second interval between actions to prevent thrashing

## Testing

- All metrics tests pass (6/6)
- All backpressure strategy tests pass (10/10)
- Validates state transitions and concurrency calculations

Addresses background task bloat and excessive memory caching when disk I/O cannot keep pace with network download speeds.