### PR TITLE
chore: add Lefthook hooks, Commitlint config, and Development README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,27 @@ then \quad &thread_t = thread_{t-1} + 1 \\
 else \quad & thread_t = thread_{t-1}
 \end{align}
 ```
+
+## Development
+
+Install [Lefthook](https://lefthook.dev/) and [Deno](https://deno.com/) before
+working on this repository.
+
+```bash
+lefthook install
+```
+
+The configured Git hooks run the following checks:
+
+- `cargo fmt --all -- --check` for Rust formatting.
+- `cargo clippy --all-targets --all-features -- -D warnings` for Rust linting.
+- `deno fmt --check` for TypeScript and JavaScript formatting.
+- `deno lint` for TypeScript and JavaScript linting.
+- `deno run -A npm:@commitlint/cli --config commitlint.config.ts --edit {1}`
+  for commit message validation.
+
+Commit messages must follow the Conventional Commits style, for example:
+
+```text
+feat: add resumable download support
+```

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,0 +1,34 @@
+export default {
+  rules: {
+    "body-leading-blank": [2, "always"],
+    "footer-leading-blank": [2, "always"],
+    "header-max-length": [2, "always", 100],
+    "scope-case": [2, "always", "kebab-case"],
+    "subject-case": [
+      2,
+      "never",
+      ["sentence-case", "start-case", "pascal-case", "upper-case"],
+    ],
+    "subject-empty": [2, "never"],
+    "subject-full-stop": [2, "never", "."],
+    "type-case": [2, "always", "lower-case"],
+    "type-empty": [2, "never"],
+    "type-enum": [
+      2,
+      "always",
+      [
+        "build",
+        "chore",
+        "ci",
+        "docs",
+        "feat",
+        "fix",
+        "perf",
+        "refactor",
+        "revert",
+        "style",
+        "test",
+      ],
+    ],
+  },
+};

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,33 @@
+pre-commit:
+  parallel: true
+  jobs:
+    - name: Backend fmt
+      run: cargo fmt --all -- --check
+      glob:
+        - "**/*.rs"
+        - "rustfmt.toml"
+    - name: Backend Checker
+      run: cargo clippy --all-targets --all-features -- -D warnings
+      glob:
+        - "**/*.rs"
+        - "Cargo.toml"
+        - "Cargo.lock"
+    - name: Deno fmt
+      run: deno fmt --check
+      glob:
+        - "**/*.ts"
+        - "**/*.tsx"
+        - "**/*.js"
+        - "**/*.jsx"
+    - name: Deno lint
+      run: deno lint
+      glob:
+        - "**/*.ts"
+        - "**/*.tsx"
+        - "**/*.js"
+        - "**/*.jsx"
+
+commit-msg:
+  jobs:
+    - name: Commitlint
+      run: deno run -A npm:@commitlint/cli --config commitlint.config.ts --edit {1}


### PR DESCRIPTION
### Motivation

- Enforce consistent formatting and linting on commits and validate commit messages, and document the developer setup for the repository.

### Description

- Add `lefthook.yml` to configure `pre-commit` jobs for `cargo fmt`, `cargo clippy`, `deno fmt`, and `deno lint`, and a `commit-msg` job that runs Commitlint via Deno. 
- Add `commitlint.config.ts` containing Conventional Commits validation rules and allowed commit types. 
- Append a `Development` section to `README.md` that documents installing Lefthook and Deno, how to run `lefthook install`, the checks the hooks run, and an example commit message.

### Testing

- Ran `git diff --check -- README.md commitlint.config.ts lefthook.yml`, which succeeded with no whitespace or diff-check problems. 
- Attempted `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings`, which could not run because the environment lacks the `rustfmt` and `clippy` components for the active toolchain. 
- Attempted `deno fmt --check` which could not run because `deno` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd7f24a5488320aa7859db798a8602)