### PR TITLE
refactor(task): add writer backpressure gate

### DIFF
--- a/crates/bolt-load/src/task/instance/concurrent_task/file_writer.rs
+++ b/crates/bolt-load/src/task/instance/concurrent_task/file_writer.rs
@@ -8,6 +8,7 @@ mod compio_writer;
 #[cfg(feature = "mmap")]
 mod mmap_writer;
 mod null_writer;
+mod pending_writer;
 mod pool_writer;
 #[cfg(test)]
 mod slow;
@@ -20,6 +21,7 @@ use std::{
 
 use bytes::Bytes;
 use fs_err::{File, OpenOptions};
+use futures::future::BoxFuture;
 use snafu::prelude::*;
 
 #[cfg(feature = "compio")]
@@ -28,10 +30,16 @@ pub use self::compio_writer::CompioWriterBuilder;
 pub use self::mmap_writer::MmapWriterBuilder;
 use self::{null_writer::NullWriter, pool_writer::PoolWriter};
 // Re-export builders for benchmarking and advanced usage
-pub use self::{null_writer::NullWriterBuilder, pool_writer::PoolWriterBuilder};
+pub use self::{
+    null_writer::NullWriterBuilder,
+    pending_writer::{PendingWrite, PendingWriter, WriteCompletion, WriteStatus, WriterFullError},
+    pool_writer::PoolWriterBuilder,
+};
 use crate::runtime::yield_now;
 
 const FILE_WRITER_QUEUE_SIZE: usize = 2048;
+
+pub type FileWriterFuture<'a> = BoxFuture<'a, Result<(), FileWriterError>>;
 
 #[derive(Debug, Snafu)]
 pub enum CommandError {
@@ -68,20 +76,19 @@ pub enum FileWriterError {
 }
 
 #[enum_dispatch::enum_dispatch(FileRangeWriterImpl)]
-#[allow(async_fn_in_trait)] // Only for benchmarking and advanced usage
 pub trait FileRangeWriter {
     /// Write data to file
     ///
     /// # Errors
     ///
     /// This function will return an error if the file is not writable or the disk is full.
-    async fn write_range(&self, range: Range<u64>, data: Bytes) -> Result<(), FileWriterError>;
+    fn write_range(&self, range: Range<u64>, data: Bytes) -> FileWriterFuture<'_>;
     /// Sync all data to disk
     ///
     /// # Errors
     ///
     /// This function will return an error if the file is not writable or the disk is full.
-    async fn finalize(self) -> Result<(), FileWriterError>;
+    fn finalize(self) -> FileWriterFuture<'static>;
 }
 
 trait FileWriterCapability {
@@ -103,31 +110,35 @@ pub enum FileRangeWriterImpl {
 }
 
 impl FileRangeWriter for Arc<FileRangeWriterImpl> {
-    async fn write_range(&self, range: Range<u64>, data: Bytes) -> Result<(), FileWriterError> {
-        match &**self {
-            #[cfg(feature = "mmap")]
-            FileRangeWriterImpl::Mmap(writer) => writer.write_range(range, data).await,
-            FileRangeWriterImpl::Pool(writer) => writer.write_range(range, data).await,
-            FileRangeWriterImpl::Null(writer) => writer.write_range(range, data).await,
-            #[cfg(feature = "compio")]
-            FileRangeWriterImpl::Compio(writer) => writer.write_range(range, data).await,
-            #[cfg(test)]
-            FileRangeWriterImpl::Slow(writer) => writer.write_range(range, data).await,
-        }
+    fn write_range(&self, range: Range<u64>, data: Bytes) -> FileWriterFuture<'_> {
+        Box::pin(async move {
+            match &**self {
+                #[cfg(feature = "mmap")]
+                FileRangeWriterImpl::Mmap(writer) => writer.write_range(range, data).await,
+                FileRangeWriterImpl::Pool(writer) => writer.write_range(range, data).await,
+                FileRangeWriterImpl::Null(writer) => writer.write_range(range, data).await,
+                #[cfg(feature = "compio")]
+                FileRangeWriterImpl::Compio(writer) => writer.write_range(range, data).await,
+                #[cfg(test)]
+                FileRangeWriterImpl::Slow(writer) => writer.write_range(range, data).await,
+            }
+        })
     }
 
-    async fn finalize(mut self) -> Result<(), FileWriterError> {
-        // A spinlock to wait all write tasks to finish, and then finalize the file.
-        let inner = loop {
-            match Arc::try_unwrap(self) {
-                Ok(inner) => break inner,
-                Err(arc) => {
-                    self = arc;
-                    yield_now().await;
+    fn finalize(mut self) -> FileWriterFuture<'static> {
+        Box::pin(async move {
+            // A spinlock to wait all write tasks to finish, and then finalize the file.
+            let inner = loop {
+                match Arc::try_unwrap(self) {
+                    Ok(inner) => break inner,
+                    Err(arc) => {
+                        self = arc;
+                        yield_now().await;
+                    }
                 }
-            }
-        };
-        inner.finalize().await
+            };
+            inner.finalize().await
+        })
     }
 }
 
@@ -258,22 +269,34 @@ impl FileWriter {
 }
 
 impl FileRangeWriter for FileWriter {
-    async fn write_range(&self, range: Range<u64>, data: Bytes) -> Result<(), FileWriterError> {
-        self.inner.write_range(range, data).await
+    fn write_range(&self, range: Range<u64>, data: Bytes) -> FileWriterFuture<'_> {
+        Box::pin(async move { self.inner.write_range(range, data).await })
     }
 
-    async fn finalize(self) -> Result<(), FileWriterError> {
-        self.inner.finalize().await
+    fn finalize(self) -> FileWriterFuture<'static> {
+        Box::pin(async move { self.inner.finalize().await })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::io::{Read, Seek, SeekFrom};
+    use std::{
+        collections::{BTreeSet, HashMap},
+        io::{Read, Seek, SeekFrom},
+        sync::Arc,
+        time::Duration,
+    };
 
+    use async_waitgroup::WaitGroup;
+    use bolt_load_tests::adapter::simple::{SimpleTestAdapterBuilder, calculate_blake3};
+    use smol_cancellation_token::CancellationToken;
     use tempfile::TempDir;
 
-    use super::*;
+    use super::{
+        super::{ConcurrentTaskInner, RunnerManager, runner_manager::TaskState},
+        *,
+    };
+    use crate::{adapter::BoltLoadAdapter, runtime::ThreadedRuntimeImpl};
 
     #[test]
     #[cfg(feature = "compio")]
@@ -582,5 +605,170 @@ mod tests {
         let mut buf = vec![0u8; data.len()];
         file.read_exact(&mut buf).unwrap();
         assert_eq!(&buf, &data[..]);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[n0_tracing_test::traced_test]
+    async fn test_slow_writer_backpressure_multi_runner_byte_integrity() {
+        const TOTAL_SIZE: usize = 256 * 1024;
+        const CHUNK_SIZE: usize = 1024;
+        const RUNNER_COUNT: usize = 4;
+
+        fn record_completions(
+            completions: Vec<WriteCompletion>,
+            written_bytes: &mut usize,
+            write_count: &mut usize,
+        ) {
+            for completion in completions {
+                let range = completion.range;
+                completion
+                    .result
+                    .unwrap_or_else(|error| panic!("write failed at {range:?}: {error}"));
+                *written_bytes += (range.end - range.start) as usize;
+                *write_count += 1;
+            }
+        }
+
+        let rt = ThreadedRuntimeImpl::new_tokio_rt();
+        let adapter = SimpleTestAdapterBuilder::new()
+            .content_size(TOTAL_SIZE)
+            .chunk_size(CHUNK_SIZE)
+            .support_range(true)
+            .build()
+            .expect("adapter should build");
+        let expected_hash = adapter.expected_hash().to_string();
+        let adapter = Arc::new(Box::new(adapter) as Box<dyn BoltLoadAdapter + Send>);
+
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("slow_backpressure_multi_runner.bin");
+        let slow_cfg = slow::SlowDiskConfig {
+            latency: Duration::from_millis(10),
+            max_jitter: Duration::from_millis(2),
+        };
+        let file_writer = FileWriter::new_with_kind(
+            &file_path,
+            TOTAL_SIZE as u64,
+            FileRangeWriterKind::Slow(slow_cfg),
+        )
+        .await
+        .expect("slow file writer should build");
+
+        let mut pending_writer = PendingWriter::new(Arc::new(file_writer.clone()), rt.clone(), 1);
+        let mut runner_manager = RunnerManager::new(TOTAL_SIZE as u64, RUNNER_COUNT);
+        let runners_cancel_token = CancellationToken::new();
+        let wg = WaitGroup::new();
+        let partition_size = TOTAL_SIZE as u64 / RUNNER_COUNT as u64;
+
+        for idx in 0..RUNNER_COUNT {
+            let start = idx as u64 * partition_size;
+            let end = if idx + 1 == RUNNER_COUNT {
+                TOTAL_SIZE as u64
+            } else {
+                start + partition_size
+            };
+            let range = start..end;
+            let runner_range = range.clone();
+            let adapter = adapter.clone();
+            let token = runners_cancel_token.clone();
+
+            runner_manager
+                .allocate_pending_runner_with_chunk(range, |runner_id, control_rx| {
+                    ConcurrentTaskInner::create_background_range_runner(
+                        &rt,
+                        &wg,
+                        runner_range,
+                        adapter,
+                        control_rx,
+                        runner_id,
+                        token,
+                    )
+                })
+                .expect("runner slot should be available");
+        }
+
+        let mut meters = HashMap::with_capacity(RUNNER_COUNT);
+        let mut written_bytes = 0usize;
+        let mut write_count = 0usize;
+        let mut downloaded_chunks = 0usize;
+        let mut touched_partitions = BTreeSet::new();
+        let mut observed_backpressure = false;
+
+        let download_result = tokio::time::timeout(Duration::from_secs(15), async {
+            loop {
+                record_completions(
+                    pending_writer.try_tick(),
+                    &mut written_bytes,
+                    &mut write_count,
+                );
+
+                if !pending_writer.can_write() {
+                    observed_backpressure = true;
+                    let completions = pending_writer
+                        .tick()
+                        .await
+                        .expect("writer completion channel should stay open");
+                    record_completions(completions, &mut written_bytes, &mut write_count);
+                    continue;
+                }
+
+                let tick = runner_manager.tick(&mut meters).await;
+                if let Some(chunk) = tick.downloaded {
+                    downloaded_chunks += 1;
+                    touched_partitions.insert(
+                        (chunk.range.start / partition_size).min((RUNNER_COUNT - 1) as u64),
+                    );
+
+                    let status = pending_writer
+                        .write_range(chunk.range, chunk.bytes)
+                        .expect("backpressure gate should only write when capacity is available");
+                    if status == WriteStatus::Pending || !pending_writer.can_write() {
+                        observed_backpressure = true;
+                    }
+                }
+
+                if tick.state == TaskState::Finished {
+                    break;
+                }
+            }
+        })
+        .await;
+
+        if download_result.is_err() {
+            runners_cancel_token.cancel();
+        }
+        download_result.expect("multi-runner download should not time out");
+
+        wg.wait().await;
+        let completions = pending_writer.flush().await;
+        record_completions(completions, &mut written_bytes, &mut write_count);
+        drop(pending_writer);
+
+        file_writer
+            .finalize()
+            .await
+            .expect("slow writer should finalize");
+
+        assert!(
+            observed_backpressure,
+            "slow writer should force the runner loop to wait for write capacity"
+        );
+        assert_eq!(
+            touched_partitions.len(),
+            RUNNER_COUNT,
+            "all runner ranges should contribute bytes"
+        );
+        assert!(
+            downloaded_chunks >= RUNNER_COUNT,
+            "expected chunks from multiple runner ranges, got {downloaded_chunks}"
+        );
+        assert!(
+            write_count >= RUNNER_COUNT,
+            "expected multiple writes, got {write_count}"
+        );
+        assert_eq!(written_bytes, TOTAL_SIZE);
+
+        let content = std::fs::read(&file_path).unwrap();
+        assert_eq!(content.len(), TOTAL_SIZE);
+        assert_eq!(calculate_blake3(&content), expected_hash);
     }
 }

--- a/crates/bolt-load/src/task/instance/concurrent_task/file_writer/compio_writer.rs
+++ b/crates/bolt-load/src/task/instance/concurrent_task/file_writer/compio_writer.rs
@@ -8,7 +8,8 @@ use snafu::prelude::*;
 
 use super::{
     Chunk, CommandError, FileRangeWriter, FileWriterBuilderError, FileWriterCapability,
-    FileWriterError, FinalizeSnafu, OpenOrCreateFileSnafu, ValidationSnafu, WriteRangeSnafu,
+    FileWriterError, FileWriterFuture, FinalizeSnafu, OpenOrCreateFileSnafu, ValidationSnafu,
+    WriteRangeSnafu,
 };
 
 enum Command {
@@ -22,54 +23,58 @@ pub struct CompioWriter {
 }
 
 impl FileRangeWriter for CompioWriter {
-    async fn write_range(&self, range: Range<u64>, data: Bytes) -> Result<(), FileWriterError> {
-        let (tx, rx) = oneshot::channel();
-        let chunk = Chunk { range, data };
-        self.tx
-            .send(Command::Write(chunk.clone(), tx))
-            .await
-            .map_err(|e| {
-                let Command::Write(chunk, _) = e.into_inner() else {
-                    unreachable!()
-                };
-                FileWriterError::WriteRange {
-                    source: CommandError::Send,
+    fn write_range(&self, range: Range<u64>, data: Bytes) -> FileWriterFuture<'_> {
+        Box::pin(async move {
+            let (tx, rx) = oneshot::channel();
+            let chunk = Chunk { range, data };
+            self.tx
+                .send(Command::Write(chunk.clone(), tx))
+                .await
+                .map_err(|e| {
+                    let Command::Write(chunk, _) = e.into_inner() else {
+                        unreachable!()
+                    };
+                    FileWriterError::WriteRange {
+                        source: CommandError::Send,
+                        chunk: Some(chunk),
+                        path: self.path.clone(),
+                    }
+                })?;
+            rx.await
+                .map_err(|_| CommandError::Recv)
+                .with_context(|_| WriteRangeSnafu {
+                    chunk: Some(chunk.clone()),
+                    path: self.path.clone(),
+                })?
+                .map_err(CommandError::from)
+                .with_context(|_| WriteRangeSnafu {
                     chunk: Some(chunk),
                     path: self.path.clone(),
-                }
-            })?;
-        rx.await
-            .map_err(|_| CommandError::Recv)
-            .with_context(|_| WriteRangeSnafu {
-                chunk: Some(chunk.clone()),
-                path: self.path.clone(),
-            })?
-            .map_err(CommandError::from)
-            .with_context(|_| WriteRangeSnafu {
-                chunk: Some(chunk),
-                path: self.path.clone(),
-            })?;
-        Ok(())
+                })?;
+            Ok(())
+        })
     }
-    async fn finalize(self) -> Result<(), FileWriterError> {
-        let (tx, rx) = oneshot::channel();
-        self.tx
-            .send(Command::Finalize(tx))
-            .await
-            .map_err(|_| CommandError::Send)
-            .with_context(|_| FinalizeSnafu {
-                path: self.path.clone(),
-            })?;
-        rx.await
-            .map_err(|_| CommandError::Recv)
-            .with_context(|_| FinalizeSnafu {
-                path: self.path.clone(),
-            })?
-            .map_err(CommandError::from)
-            .with_context(|_| FinalizeSnafu {
-                path: self.path.clone(),
-            })?;
-        Ok(())
+    fn finalize(self) -> FileWriterFuture<'static> {
+        Box::pin(async move {
+            let (tx, rx) = oneshot::channel();
+            self.tx
+                .send(Command::Finalize(tx))
+                .await
+                .map_err(|_| CommandError::Send)
+                .with_context(|_| FinalizeSnafu {
+                    path: self.path.clone(),
+                })?;
+            rx.await
+                .map_err(|_| CommandError::Recv)
+                .with_context(|_| FinalizeSnafu {
+                    path: self.path.clone(),
+                })?
+                .map_err(CommandError::from)
+                .with_context(|_| FinalizeSnafu {
+                    path: self.path.clone(),
+                })?;
+            Ok(())
+        })
     }
 }
 

--- a/crates/bolt-load/src/task/instance/concurrent_task/file_writer/mmap_writer.rs
+++ b/crates/bolt-load/src/task/instance/concurrent_task/file_writer/mmap_writer.rs
@@ -10,7 +10,8 @@ use snafu::prelude::*;
 
 use super::{
     Chunk, CommandError, FileRangeWriter, FileWriterBuilderError, FileWriterCapability,
-    FileWriterError, FinalizeSnafu, OpenOrCreateFileSnafu, ValidationSnafu, WriteRangeSnafu,
+    FileWriterError, FileWriterFuture, FinalizeSnafu, OpenOrCreateFileSnafu, ValidationSnafu,
+    WriteRangeSnafu,
 };
 
 pub struct MmapWriter {
@@ -19,55 +20,59 @@ pub struct MmapWriter {
 }
 
 impl FileRangeWriter for MmapWriter {
-    async fn finalize(self) -> Result<(), FileWriterError> {
-        let (tx, rx) = oneshot::channel();
-        self.tx
-            .send(Command::Finalize(tx))
-            .await
-            .map_err(|_| CommandError::Send)
-            .with_context(|_| FinalizeSnafu {
-                path: self.file.path().to_path_buf(),
-            })?;
-        rx.await
-            .map_err(|_| CommandError::Recv)
-            .with_context(|_| FinalizeSnafu {
-                path: self.file.path().to_path_buf(),
-            })?
-            .map_err(CommandError::from)
-            .with_context(|_| FinalizeSnafu {
-                path: self.file.path().to_path_buf(),
-            })?;
-        Ok(())
+    fn finalize(self) -> FileWriterFuture<'static> {
+        Box::pin(async move {
+            let (tx, rx) = oneshot::channel();
+            self.tx
+                .send(Command::Finalize(tx))
+                .await
+                .map_err(|_| CommandError::Send)
+                .with_context(|_| FinalizeSnafu {
+                    path: self.file.path().to_path_buf(),
+                })?;
+            rx.await
+                .map_err(|_| CommandError::Recv)
+                .with_context(|_| FinalizeSnafu {
+                    path: self.file.path().to_path_buf(),
+                })?
+                .map_err(CommandError::from)
+                .with_context(|_| FinalizeSnafu {
+                    path: self.file.path().to_path_buf(),
+                })?;
+            Ok(())
+        })
     }
 
-    async fn write_range(&self, range: Range<u64>, data: Bytes) -> Result<(), FileWriterError> {
-        let (tx, rx) = oneshot::channel();
-        let chunk = Chunk { range, data };
-        self.tx
-            .send(Command::Write(chunk.clone(), tx))
-            .await
-            .map_err(|e| {
-                let Command::Write(chunk, _) = e.into_inner() else {
-                    unreachable!()
-                };
-                FileWriterError::WriteRange {
-                    source: CommandError::Send,
+    fn write_range(&self, range: Range<u64>, data: Bytes) -> FileWriterFuture<'_> {
+        Box::pin(async move {
+            let (tx, rx) = oneshot::channel();
+            let chunk = Chunk { range, data };
+            self.tx
+                .send(Command::Write(chunk.clone(), tx))
+                .await
+                .map_err(|e| {
+                    let Command::Write(chunk, _) = e.into_inner() else {
+                        unreachable!()
+                    };
+                    FileWriterError::WriteRange {
+                        source: CommandError::Send,
+                        chunk: Some(chunk),
+                        path: self.file.path().to_path_buf(),
+                    }
+                })?;
+            rx.await
+                .map_err(|_| CommandError::Recv)
+                .with_context(|_| WriteRangeSnafu {
+                    chunk: Some(chunk.clone()),
+                    path: self.file.path().to_path_buf(),
+                })?
+                .map_err(CommandError::from)
+                .with_context(|_| WriteRangeSnafu {
                     chunk: Some(chunk),
                     path: self.file.path().to_path_buf(),
-                }
-            })?;
-        rx.await
-            .map_err(|_| CommandError::Recv)
-            .with_context(|_| WriteRangeSnafu {
-                chunk: Some(chunk.clone()),
-                path: self.file.path().to_path_buf(),
-            })?
-            .map_err(CommandError::from)
-            .with_context(|_| WriteRangeSnafu {
-                chunk: Some(chunk),
-                path: self.file.path().to_path_buf(),
-            })?;
-        Ok(())
+                })?;
+            Ok(())
+        })
     }
 }
 

--- a/crates/bolt-load/src/task/instance/concurrent_task/file_writer/null_writer.rs
+++ b/crates/bolt-load/src/task/instance/concurrent_task/file_writer/null_writer.rs
@@ -13,7 +13,7 @@ use snafu::prelude::*;
 
 use super::{
     Chunk, CommandError, FileRangeWriter, FileWriterBuilderError, FileWriterCapability,
-    FileWriterError, FinalizeSnafu, OpenOrCreateFileSnafu, WriteRangeSnafu,
+    FileWriterError, FileWriterFuture, FinalizeSnafu, OpenOrCreateFileSnafu, WriteRangeSnafu,
 };
 
 enum Command {
@@ -33,55 +33,59 @@ pub struct NullWriter {
 const NULL_PATH: &str = "<null>";
 
 impl FileRangeWriter for NullWriter {
-    async fn write_range(&self, range: Range<u64>, data: Bytes) -> Result<(), FileWriterError> {
-        let (tx, rx) = oneshot::channel();
-        let chunk = Chunk { range, data };
-        self.tx
-            .send(Command::Write(chunk.clone(), tx))
-            .await
-            .map_err(|e| {
-                let Command::Write(chunk, _) = e.into_inner() else {
-                    unreachable!()
-                };
-                FileWriterError::WriteRange {
-                    source: CommandError::Send,
+    fn write_range(&self, range: Range<u64>, data: Bytes) -> FileWriterFuture<'_> {
+        Box::pin(async move {
+            let (tx, rx) = oneshot::channel();
+            let chunk = Chunk { range, data };
+            self.tx
+                .send(Command::Write(chunk.clone(), tx))
+                .await
+                .map_err(|e| {
+                    let Command::Write(chunk, _) = e.into_inner() else {
+                        unreachable!()
+                    };
+                    FileWriterError::WriteRange {
+                        source: CommandError::Send,
+                        chunk: Some(chunk),
+                        path: PathBuf::from(NULL_PATH),
+                    }
+                })?;
+            rx.await
+                .map_err(|_| CommandError::Recv)
+                .with_context(|_| WriteRangeSnafu {
+                    chunk: Some(chunk.clone()),
+                    path: PathBuf::from(NULL_PATH),
+                })?
+                .map_err(CommandError::from)
+                .with_context(|_| WriteRangeSnafu {
                     chunk: Some(chunk),
                     path: PathBuf::from(NULL_PATH),
-                }
-            })?;
-        rx.await
-            .map_err(|_| CommandError::Recv)
-            .with_context(|_| WriteRangeSnafu {
-                chunk: Some(chunk.clone()),
-                path: PathBuf::from(NULL_PATH),
-            })?
-            .map_err(CommandError::from)
-            .with_context(|_| WriteRangeSnafu {
-                chunk: Some(chunk),
-                path: PathBuf::from(NULL_PATH),
-            })?;
-        Ok(())
+                })?;
+            Ok(())
+        })
     }
 
-    async fn finalize(self) -> Result<(), FileWriterError> {
-        let (tx, rx) = oneshot::channel();
-        self.tx
-            .send(Command::Finalize(tx))
-            .await
-            .map_err(|_| CommandError::Send)
-            .with_context(|_| FinalizeSnafu {
-                path: PathBuf::from(NULL_PATH),
-            })?;
-        rx.await
-            .map_err(|_| CommandError::Recv)
-            .with_context(|_| FinalizeSnafu {
-                path: PathBuf::from(NULL_PATH),
-            })?
-            .map_err(CommandError::from)
-            .with_context(|_| FinalizeSnafu {
-                path: PathBuf::from(NULL_PATH),
-            })?;
-        Ok(())
+    fn finalize(self) -> FileWriterFuture<'static> {
+        Box::pin(async move {
+            let (tx, rx) = oneshot::channel();
+            self.tx
+                .send(Command::Finalize(tx))
+                .await
+                .map_err(|_| CommandError::Send)
+                .with_context(|_| FinalizeSnafu {
+                    path: PathBuf::from(NULL_PATH),
+                })?;
+            rx.await
+                .map_err(|_| CommandError::Recv)
+                .with_context(|_| FinalizeSnafu {
+                    path: PathBuf::from(NULL_PATH),
+                })?
+                .map_err(CommandError::from)
+                .with_context(|_| FinalizeSnafu {
+                    path: PathBuf::from(NULL_PATH),
+                })?;
+            Ok(())
+        })
     }
 }
 

--- a/crates/bolt-load/src/task/instance/concurrent_task/file_writer/pending_writer.rs
+++ b/crates/bolt-load/src/task/instance/concurrent_task/file_writer/pending_writer.rs
@@ -1,0 +1,698 @@
+//! Pending writer for concurrent downloads.
+//!
+//! This wraps a [`FileRangeWriter`] with bounded write dispatch. Download code
+//! can keep a small number of writes in flight and stop consuming runner data
+//! when the writer is saturated.
+
+use std::{ops::Range, path::PathBuf, sync::Arc};
+
+use async_channel::{Receiver, Sender};
+use bytes::Bytes;
+use futures::task::SpawnExt;
+
+use super::{Chunk, CommandError, FileRangeWriter, FileWriterError};
+use crate::runtime::ThreadedRuntimeImpl;
+
+/// A write request that has not completed yet.
+#[derive(derive_more::Debug, Clone)]
+pub struct PendingWrite {
+    #[debug("{}..{}", range.start, range.end)]
+    pub range: Range<u64>,
+    #[debug("{} bytes", bytes.len())]
+    pub bytes: Bytes,
+}
+
+/// Result of a completed write.
+#[derive(Debug)]
+pub struct WriteCompletion {
+    pub range: Range<u64>,
+    pub result: Result<(), FileWriterError>,
+}
+
+struct WriteCompletionGuard {
+    tx: Sender<WriteCompletion>,
+    range: Range<u64>,
+    chunk: Option<Chunk>,
+    armed: bool,
+}
+
+impl WriteCompletionGuard {
+    fn new(tx: Sender<WriteCompletion>, range: Range<u64>, chunk: Chunk) -> Self {
+        Self {
+            tx,
+            range,
+            chunk: Some(chunk),
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+        self.chunk = None;
+    }
+}
+
+impl Drop for WriteCompletionGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+
+        let _ = self.tx.try_send(WriteCompletion {
+            range: self.range.clone(),
+            result: Err(FileWriterError::WriteRange {
+                source: CommandError::Io {
+                    source: std::io::Error::other("write task panicked"),
+                },
+                chunk: self.chunk.take(),
+                path: PathBuf::new(),
+            }),
+        });
+    }
+}
+
+/// Indicates what happened when a write was submitted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteStatus {
+    /// The write was dispatched to the background runtime immediately.
+    Dispatched,
+    /// The writer is at capacity and the write was buffered.
+    Pending,
+}
+
+/// Error returned when the writer cannot accept another write.
+#[derive(Debug, thiserror::Error)]
+#[error("writer cannot accept another write")]
+pub struct WriterFullError(pub PendingWrite);
+
+#[derive(derive_more::Debug)]
+pub struct PendingWriter<F> {
+    writer: Arc<F>,
+    #[debug(skip)]
+    threaded_rt: ThreadedRuntimeImpl,
+    capacity: usize,
+    in_flight: usize,
+
+    #[debug(skip)]
+    completion_tx: Sender<WriteCompletion>,
+    #[debug(skip)]
+    completion_rx: Receiver<WriteCompletion>,
+
+    /// At most one write is buffered while all dispatch slots are full.
+    pending_write: Option<PendingWrite>,
+    /// Once any write fails, stop accepting and auto-dispatching writes.
+    saw_error: bool,
+}
+
+impl<F> PendingWriter<F>
+where
+    F: FileRangeWriter + Send + Sync + 'static,
+{
+    pub fn new(writer: Arc<F>, threaded_rt: ThreadedRuntimeImpl, capacity: usize) -> Self {
+        let capacity = capacity.max(1);
+        let (tx, rx) = async_channel::bounded(capacity + 1);
+        Self {
+            writer,
+            threaded_rt,
+            capacity,
+            in_flight: 0,
+            completion_tx: tx,
+            completion_rx: rx,
+            pending_write: None,
+            saw_error: false,
+        }
+    }
+
+    #[inline]
+    pub fn in_flight_count(&self) -> usize {
+        self.in_flight
+    }
+
+    #[inline]
+    pub fn is_full(&self) -> bool {
+        self.in_flight_count() >= self.capacity
+    }
+
+    #[inline]
+    pub fn has_pending_write(&self) -> bool {
+        self.pending_write.is_some()
+    }
+
+    #[inline]
+    pub fn is_idle(&self) -> bool {
+        self.in_flight_count() == 0 && !self.has_pending_write()
+    }
+
+    #[inline]
+    pub fn can_write(&self) -> bool {
+        !self.saw_error && (!self.is_full() || !self.has_pending_write())
+    }
+
+    pub fn write_range(
+        &mut self,
+        range: Range<u64>,
+        data: Bytes,
+    ) -> Result<WriteStatus, WriterFullError> {
+        let write = PendingWrite { range, bytes: data };
+        if self.saw_error {
+            return Err(WriterFullError(write));
+        }
+
+        if !self.is_full() {
+            self.dispatch_write(write.range, write.bytes);
+            Ok(WriteStatus::Dispatched)
+        } else if self.pending_write.is_none() {
+            self.pending_write = Some(write);
+            Ok(WriteStatus::Pending)
+        } else {
+            Err(WriterFullError(write))
+        }
+    }
+
+    /// Drain already completed writes without blocking.
+    pub fn try_tick(&mut self) -> Vec<WriteCompletion> {
+        let completions = self.drain_completions();
+        self.saw_error |= Self::completions_have_error(&completions);
+        if !self.saw_error {
+            self.try_flush_pending();
+        }
+        completions
+    }
+
+    /// Wait for at least one in-flight write to finish, then drain the rest.
+    pub async fn tick(&mut self) -> Option<Vec<WriteCompletion>> {
+        if self.in_flight_count() == 0 {
+            return Some(Vec::new());
+        }
+
+        let first = self.completion_rx.recv().await.ok()?;
+        let mut completions = vec![first];
+        while let Ok(completion) = self.completion_rx.try_recv() {
+            completions.push(completion);
+        }
+        self.ack_completions(completions.len());
+        self.saw_error |= Self::completions_have_error(&completions);
+        if !self.saw_error {
+            self.try_flush_pending();
+        }
+        Some(completions)
+    }
+
+    /// Wait until all dispatched writes finish.
+    pub async fn flush(&mut self) -> Vec<WriteCompletion> {
+        let mut completions = Vec::new();
+
+        loop {
+            let drained = self.drain_completions();
+            self.saw_error |= Self::completions_have_error(&drained);
+            completions.extend(drained);
+
+            if !self.saw_error {
+                self.try_flush_pending();
+            }
+
+            if self.in_flight_count() == 0 {
+                break;
+            }
+
+            match self.completion_rx.recv().await {
+                Ok(completion) => {
+                    self.ack_completions(1);
+                    self.saw_error |= completion.result.is_err();
+                    completions.push(completion);
+                }
+                Err(_) => break,
+            }
+        }
+
+        completions.extend(self.drain_completions());
+        completions
+    }
+
+    fn completions_have_error(completions: &[WriteCompletion]) -> bool {
+        completions
+            .iter()
+            .any(|completion| completion.result.is_err())
+    }
+
+    fn ack_completions(&mut self, count: usize) {
+        self.in_flight = self
+            .in_flight
+            .checked_sub(count)
+            .expect("in_flight underflow: more completions drained than dispatched");
+    }
+
+    fn dispatch_write(&mut self, range: Range<u64>, data: Bytes) {
+        self.in_flight += 1;
+
+        let writer = Arc::clone(&self.writer);
+        let tx = self.completion_tx.clone();
+        let task_range = range.clone();
+        let completion_range = range.clone();
+        let guard_range = range.clone();
+        let guard_chunk = Chunk {
+            range: range.clone(),
+            data: data.clone(),
+        };
+        let completion_chunk = Chunk {
+            range,
+            data: data.clone(),
+        };
+
+        if let Err(spawn_error) = self.threaded_rt.spawn(async move {
+            let mut guard = WriteCompletionGuard::new(tx.clone(), guard_range, guard_chunk);
+            let result = writer.write_range(task_range.clone(), data).await;
+            let _ = tx
+                .send(WriteCompletion {
+                    range: task_range,
+                    result,
+                })
+                .await;
+            guard.disarm();
+        }) {
+            self.completion_tx
+                .try_send(WriteCompletion {
+                    range: completion_range,
+                    result: Err(FileWriterError::WriteRange {
+                        source: CommandError::Io {
+                            source: std::io::Error::other(format!(
+                                "failed to spawn write task: {spawn_error}"
+                            )),
+                        },
+                        chunk: Some(completion_chunk),
+                        path: PathBuf::new(),
+                    }),
+                })
+                .expect("completion channel should have capacity for spawn-failure completion");
+        }
+    }
+
+    fn try_flush_pending(&mut self) {
+        if !self.is_full() {
+            if let Some(pending) = self.pending_write.take() {
+                self.dispatch_write(pending.range, pending.bytes);
+            }
+        }
+    }
+
+    fn drain_completions(&mut self) -> Vec<WriteCompletion> {
+        let mut completions = Vec::new();
+        while let Ok(completion) = self.completion_rx.try_recv() {
+            completions.push(completion);
+        }
+        self.ack_completions(completions.len());
+        completions
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+
+    use async_channel::Receiver;
+    use bytes::Bytes;
+    use futures::{
+        future::FutureObj,
+        task::{Spawn, SpawnError},
+    };
+
+    use super::{super::FileWriterFuture, *};
+    use crate::runtime::{
+        DowncastLocalRuntime, ObjectSafeTimer, ThreadedRuntime, TimerBuilder, TimerImpl,
+    };
+
+    #[derive(Debug, Default)]
+    struct RecordingWriter {
+        writes: Mutex<Vec<(Range<u64>, Bytes)>>,
+    }
+
+    impl RecordingWriter {
+        fn writes(&self) -> Vec<(Range<u64>, Bytes)> {
+            self.writes.lock().unwrap().clone()
+        }
+    }
+
+    impl FileRangeWriter for RecordingWriter {
+        fn write_range(&self, range: Range<u64>, data: Bytes) -> FileWriterFuture<'_> {
+            Box::pin(async move {
+                self.writes.lock().unwrap().push((range, data));
+                Ok(())
+            })
+        }
+
+        fn finalize(self) -> FileWriterFuture<'static> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    #[derive(Debug)]
+    struct ControlledWriter {
+        writes: Mutex<Vec<(Range<u64>, Bytes)>>,
+        release_rx: Receiver<()>,
+    }
+
+    impl ControlledWriter {
+        fn new(release_rx: Receiver<()>) -> Self {
+            Self {
+                writes: Mutex::new(Vec::new()),
+                release_rx,
+            }
+        }
+
+        fn writes(&self) -> Vec<(Range<u64>, Bytes)> {
+            self.writes.lock().unwrap().clone()
+        }
+    }
+
+    impl FileRangeWriter for ControlledWriter {
+        fn write_range(&self, range: Range<u64>, data: Bytes) -> FileWriterFuture<'_> {
+            Box::pin(async move {
+                let _ = self.release_rx.recv().await;
+                self.writes.lock().unwrap().push((range, data));
+                Ok(())
+            })
+        }
+
+        fn finalize(self) -> FileWriterFuture<'static> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct FailingRuntime;
+
+    impl Spawn for FailingRuntime {
+        fn spawn_obj(&self, _future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
+            Err(SpawnError::shutdown())
+        }
+    }
+
+    impl DowncastLocalRuntime for FailingRuntime {}
+
+    impl TimerBuilder for FailingRuntime {
+        fn create_delayed_timer(&self, _duration: Duration) -> TimerImpl {
+            TimerImpl::Custom(Box::new(NoopTimer))
+        }
+    }
+
+    impl ThreadedRuntime for FailingRuntime {}
+
+    #[derive(Debug)]
+    struct PanicWriter;
+
+    impl FileRangeWriter for PanicWriter {
+        fn write_range(&self, _range: Range<u64>, _data: Bytes) -> FileWriterFuture<'_> {
+            Box::pin(async { panic!("injected write panic") })
+        }
+
+        fn finalize(self) -> FileWriterFuture<'static> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    struct NoopTimer;
+
+    #[async_trait::async_trait]
+    impl ObjectSafeTimer for NoopTimer {
+        async fn tick(&mut self) {}
+    }
+
+    #[derive(Debug)]
+    struct ControlledFailingWriter {
+        release_rx: Receiver<()>,
+    }
+
+    impl FileRangeWriter for ControlledFailingWriter {
+        fn write_range(&self, range: Range<u64>, data: Bytes) -> FileWriterFuture<'_> {
+            Box::pin(async move {
+                let _ = self.release_rx.recv().await;
+                Err(FileWriterError::WriteRange {
+                    source: CommandError::Io {
+                        source: std::io::Error::other("injected failure"),
+                    },
+                    chunk: Some(Chunk { range, data }),
+                    path: PathBuf::new(),
+                })
+            })
+        }
+
+        fn finalize(self) -> FileWriterFuture<'static> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    #[derive(Debug)]
+    struct DelayWriter {
+        delay: Duration,
+    }
+
+    impl FileRangeWriter for DelayWriter {
+        fn write_range(&self, _range: Range<u64>, _data: Bytes) -> FileWriterFuture<'_> {
+            Box::pin(async move {
+                tokio::time::sleep(self.delay).await;
+                Ok(())
+            })
+        }
+
+        fn finalize(self) -> FileWriterFuture<'static> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    async fn next_tick<F>(writer: &mut PendingWriter<F>) -> Vec<WriteCompletion>
+    where
+        F: FileRangeWriter + Send + Sync + 'static,
+    {
+        tokio::time::timeout(Duration::from_secs(1), writer.tick())
+            .await
+            .expect("timed out waiting for write completion")
+            .expect("completion channel closed")
+    }
+
+    #[tokio::test]
+    async fn basic_write_tick_completion() {
+        let writer = Arc::new(RecordingWriter::default());
+        let mut pending =
+            PendingWriter::new(Arc::clone(&writer), ThreadedRuntimeImpl::new_tokio_rt(), 2);
+
+        assert_eq!(
+            pending
+                .write_range(0..4, Bytes::from_static(b"test"))
+                .unwrap(),
+            WriteStatus::Dispatched
+        );
+
+        let completions = next_tick(&mut pending).await;
+        assert_eq!(completions.len(), 1);
+        assert_eq!(completions[0].range, 0..4);
+        assert!(completions[0].result.is_ok());
+        assert!(pending.is_idle());
+
+        let writes = writer.writes();
+        assert_eq!(writes.len(), 1);
+        assert_eq!(writes[0].0, 0..4);
+        assert_eq!(&writes[0].1[..], b"test");
+    }
+
+    #[tokio::test]
+    async fn pending_buffer_flushes_after_capacity_opens() {
+        let (release_tx, release_rx) = async_channel::unbounded();
+        let writer = Arc::new(ControlledWriter::new(release_rx));
+        let mut pending =
+            PendingWriter::new(Arc::clone(&writer), ThreadedRuntimeImpl::new_tokio_rt(), 1);
+
+        assert_eq!(
+            pending.write_range(0..1, Bytes::from_static(b"a")).unwrap(),
+            WriteStatus::Dispatched
+        );
+        assert_eq!(
+            pending.write_range(1..2, Bytes::from_static(b"b")).unwrap(),
+            WriteStatus::Pending
+        );
+        assert!(pending.is_full());
+        assert!(pending.has_pending_write());
+
+        release_tx.send(()).await.unwrap();
+        let first = next_tick(&mut pending).await;
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].range, 0..1);
+        assert!(first[0].result.is_ok());
+        assert!(!pending.has_pending_write());
+        assert!(pending.is_full());
+
+        release_tx.send(()).await.unwrap();
+        let second = next_tick(&mut pending).await;
+        assert_eq!(second.len(), 1);
+        assert_eq!(second[0].range, 1..2);
+        assert!(second[0].result.is_ok());
+        assert!(pending.is_idle());
+
+        let writes = writer.writes();
+        assert_eq!(writes.len(), 2);
+        assert_eq!(writes[0].0, 0..1);
+        assert_eq!(writes[1].0, 1..2);
+    }
+
+    #[tokio::test]
+    async fn full_writer_rejects_third_write() {
+        let (release_tx, release_rx) = async_channel::unbounded();
+        let writer = Arc::new(ControlledWriter::new(release_rx));
+        let mut pending =
+            PendingWriter::new(Arc::clone(&writer), ThreadedRuntimeImpl::new_tokio_rt(), 1);
+
+        assert_eq!(
+            pending.write_range(0..1, Bytes::from_static(b"a")).unwrap(),
+            WriteStatus::Dispatched
+        );
+        assert_eq!(
+            pending.write_range(1..2, Bytes::from_static(b"b")).unwrap(),
+            WriteStatus::Pending
+        );
+
+        let err = pending
+            .write_range(2..3, Bytes::from_static(b"c"))
+            .unwrap_err();
+        assert_eq!(err.0.range, 2..3);
+        assert_eq!(&err.0.bytes[..], b"c");
+
+        release_tx.send(()).await.unwrap();
+        let _ = next_tick(&mut pending).await;
+        release_tx.send(()).await.unwrap();
+        let _ = next_tick(&mut pending).await;
+        assert!(pending.is_idle());
+    }
+
+    #[tokio::test]
+    async fn zero_capacity_is_clamped_to_one() {
+        let (release_tx, release_rx) = async_channel::unbounded();
+        let writer = Arc::new(ControlledWriter::new(release_rx));
+        let mut pending =
+            PendingWriter::new(Arc::clone(&writer), ThreadedRuntimeImpl::new_tokio_rt(), 0);
+
+        assert!(!pending.is_full());
+        assert_eq!(
+            pending.write_range(0..1, Bytes::from_static(b"a")).unwrap(),
+            WriteStatus::Dispatched
+        );
+        assert_eq!(pending.in_flight_count(), 1);
+        assert!(pending.is_full());
+        assert_eq!(
+            pending.write_range(1..2, Bytes::from_static(b"b")).unwrap(),
+            WriteStatus::Pending
+        );
+
+        release_tx.send(()).await.unwrap();
+        let _ = next_tick(&mut pending).await;
+        release_tx.send(()).await.unwrap();
+        let _ = next_tick(&mut pending).await;
+        assert!(pending.is_idle());
+    }
+
+    #[tokio::test]
+    async fn spawn_error_decrements_in_flight_and_reports_completion() {
+        let writer = Arc::new(RecordingWriter::default());
+        let rt = ThreadedRuntimeImpl::new_other_rt(FailingRuntime);
+        let mut pending = PendingWriter::new(Arc::clone(&writer), rt, 1);
+
+        assert_eq!(
+            pending
+                .write_range(0..4, Bytes::from_static(b"boom"))
+                .unwrap(),
+            WriteStatus::Dispatched
+        );
+        assert_eq!(pending.in_flight_count(), 1);
+
+        let completions = next_tick(&mut pending).await;
+        assert_eq!(completions.len(), 1);
+        assert_eq!(completions[0].range, 0..4);
+        assert!(completions[0].result.is_err());
+        assert!(writer.writes().is_empty());
+        assert!(pending.is_idle());
+    }
+
+    #[tokio::test]
+    async fn panic_guard_decrements_in_flight_and_reports_completion() {
+        let writer = Arc::new(PanicWriter);
+        let mut pending =
+            PendingWriter::new(Arc::clone(&writer), ThreadedRuntimeImpl::new_tokio_rt(), 1);
+
+        assert_eq!(
+            pending
+                .write_range(0..4, Bytes::from_static(b"boom"))
+                .unwrap(),
+            WriteStatus::Dispatched
+        );
+        assert_eq!(pending.in_flight_count(), 1);
+
+        let completions = next_tick(&mut pending).await;
+        assert_eq!(completions.len(), 1);
+        assert_eq!(completions[0].range, 0..4);
+        assert!(completions[0].result.is_err());
+        assert!(pending.is_idle());
+    }
+
+    #[tokio::test]
+    async fn write_error_prevents_pending_dispatch() {
+        let (release_tx, release_rx) = async_channel::unbounded();
+        let writer = Arc::new(ControlledFailingWriter { release_rx });
+        let mut pending =
+            PendingWriter::new(Arc::clone(&writer), ThreadedRuntimeImpl::new_tokio_rt(), 1);
+
+        assert_eq!(
+            pending
+                .write_range(0..10, Bytes::from_static(b"will_fail_"))
+                .unwrap(),
+            WriteStatus::Dispatched
+        );
+        assert_eq!(
+            pending
+                .write_range(10..20, Bytes::from_static(b"should_not"))
+                .unwrap(),
+            WriteStatus::Pending
+        );
+
+        release_tx.send(()).await.unwrap();
+        let completions = next_tick(&mut pending).await;
+        assert_eq!(completions.len(), 1);
+        assert!(completions[0].result.is_err());
+        assert!(pending.has_pending_write());
+        assert_eq!(pending.in_flight_count(), 0);
+        assert!(!pending.can_write());
+    }
+
+    #[tokio::test]
+    async fn slow_writer_backpressure_no_overflow() {
+        let writer = Arc::new(DelayWriter {
+            delay: Duration::from_millis(50),
+        });
+        let mut pending =
+            PendingWriter::new(Arc::clone(&writer), ThreadedRuntimeImpl::new_tokio_rt(), 2);
+
+        pending.write_range(0..1, Bytes::from_static(b"a")).unwrap();
+        pending.write_range(1..2, Bytes::from_static(b"b")).unwrap();
+        assert!(pending.is_full());
+        assert!(pending.can_write());
+
+        pending.write_range(2..3, Bytes::from_static(b"c")).unwrap();
+        assert!(!pending.can_write());
+
+        let err = pending
+            .write_range(3..4, Bytes::from_static(b"d"))
+            .unwrap_err();
+        assert_eq!(err.0.range, 3..4);
+
+        let completions = tokio::time::timeout(Duration::from_secs(5), pending.flush())
+            .await
+            .expect("flush timed out");
+        assert_eq!(completions.len(), 3);
+        assert!(
+            completions
+                .iter()
+                .all(|completion| completion.result.is_ok())
+        );
+        assert!(pending.is_idle());
+    }
+}

--- a/crates/bolt-load/src/task/instance/concurrent_task/file_writer/pool_writer.rs
+++ b/crates/bolt-load/src/task/instance/concurrent_task/file_writer/pool_writer.rs
@@ -8,7 +8,8 @@ use snafu::prelude::*;
 
 use super::{
     Chunk, CommandError, FileRangeWriter, FileWriterBuilderError, FileWriterCapability,
-    FileWriterError, FinalizeSnafu, OpenOrCreateFileSnafu, ValidationSnafu, WriteRangeSnafu,
+    FileWriterError, FileWriterFuture, FinalizeSnafu, OpenOrCreateFileSnafu, ValidationSnafu,
+    WriteRangeSnafu,
 };
 
 pub struct PoolWriter {
@@ -22,56 +23,60 @@ enum Command {
 }
 
 impl FileRangeWriter for PoolWriter {
-    async fn finalize(self) -> Result<(), FileWriterError> {
-        let (tx, rx) = oneshot::channel();
-        self.tx
-            .send(Command::Finalize(tx))
-            .await
-            .map_err(|_| CommandError::Send)
-            .with_context(|_| FinalizeSnafu {
-                path: self.file.path().to_path_buf(),
-            })?;
-        rx.await
-            .map_err(|_| CommandError::Recv)
-            .with_context(|_| FinalizeSnafu {
-                path: self.file.path().to_path_buf(),
-            })?
-            .map_err(CommandError::from)
-            .with_context(|_| FinalizeSnafu {
-                path: self.file.path().to_path_buf(),
-            })?;
-        self.tx.close();
-        Ok(())
+    fn finalize(self) -> FileWriterFuture<'static> {
+        Box::pin(async move {
+            let (tx, rx) = oneshot::channel();
+            self.tx
+                .send(Command::Finalize(tx))
+                .await
+                .map_err(|_| CommandError::Send)
+                .with_context(|_| FinalizeSnafu {
+                    path: self.file.path().to_path_buf(),
+                })?;
+            rx.await
+                .map_err(|_| CommandError::Recv)
+                .with_context(|_| FinalizeSnafu {
+                    path: self.file.path().to_path_buf(),
+                })?
+                .map_err(CommandError::from)
+                .with_context(|_| FinalizeSnafu {
+                    path: self.file.path().to_path_buf(),
+                })?;
+            self.tx.close();
+            Ok(())
+        })
     }
 
-    async fn write_range(&self, range: Range<u64>, data: Bytes) -> Result<(), FileWriterError> {
-        let (tx, rx) = oneshot::channel();
-        let chunk = Chunk { range, data };
-        self.tx
-            .send(Command::Write(chunk.clone(), tx))
-            .await
-            .map_err(|e| {
-                let Command::Write(chunk, _) = e.into_inner() else {
-                    unreachable!()
-                };
-                FileWriterError::WriteRange {
-                    source: CommandError::Send,
+    fn write_range(&self, range: Range<u64>, data: Bytes) -> FileWriterFuture<'_> {
+        Box::pin(async move {
+            let (tx, rx) = oneshot::channel();
+            let chunk = Chunk { range, data };
+            self.tx
+                .send(Command::Write(chunk.clone(), tx))
+                .await
+                .map_err(|e| {
+                    let Command::Write(chunk, _) = e.into_inner() else {
+                        unreachable!()
+                    };
+                    FileWriterError::WriteRange {
+                        source: CommandError::Send,
+                        chunk: Some(chunk),
+                        path: self.file.path().to_path_buf(),
+                    }
+                })?;
+            rx.await
+                .map_err(|_| CommandError::Recv)
+                .with_context(|_| WriteRangeSnafu {
+                    chunk: Some(chunk.clone()),
+                    path: self.file.path().to_path_buf(),
+                })?
+                .map_err(CommandError::from)
+                .with_context(|_| WriteRangeSnafu {
                     chunk: Some(chunk),
                     path: self.file.path().to_path_buf(),
-                }
-            })?;
-        rx.await
-            .map_err(|_| CommandError::Recv)
-            .with_context(|_| WriteRangeSnafu {
-                chunk: Some(chunk.clone()),
-                path: self.file.path().to_path_buf(),
-            })?
-            .map_err(CommandError::from)
-            .with_context(|_| WriteRangeSnafu {
-                chunk: Some(chunk),
-                path: self.file.path().to_path_buf(),
-            })?;
-        Ok(())
+                })?;
+            Ok(())
+        })
     }
 }
 

--- a/crates/bolt-load/src/task/instance/concurrent_task/file_writer/slow.rs
+++ b/crates/bolt-load/src/task/instance/concurrent_task/file_writer/slow.rs
@@ -13,7 +13,10 @@ use bytes::Bytes;
 use fs_err::File;
 use snafu::prelude::*;
 
-use super::{CommandError, FileRangeWriter, FileWriterError, FinalizeSnafu, WriteRangeSnafu};
+use super::{
+    CommandError, FileRangeWriter, FileWriterError, FileWriterFuture, FinalizeSnafu,
+    WriteRangeSnafu,
+};
 use crate::runtime::yield_now;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -119,48 +122,52 @@ impl SlowWriter {
 }
 
 impl FileRangeWriter for SlowWriter {
-    async fn write_range(&self, range: Range<u64>, data: Bytes) -> Result<(), FileWriterError> {
-        self.inject_delay(range.start).await;
+    fn write_range(&self, range: Range<u64>, data: Bytes) -> FileWriterFuture<'_> {
+        Box::pin(async move {
+            self.inject_delay(range.start).await;
 
-        // NOTE: We are doing blocking IO in a blocking section to keep async runtime healthy.
-        let mut file = self
-            .file
-            .try_clone()
-            .map_err(CommandError::from)
-            .with_context(|_| WriteRangeSnafu {
-                chunk: None,
-                path: self.path.clone(),
-            })?;
-
-        let path = self.path.clone();
-        blocking::unblock(move || {
-            file.seek(SeekFrom::Start(range.start))
+            // NOTE: We are doing blocking IO in a blocking section to keep async runtime healthy.
+            let mut file = self
+                .file
+                .try_clone()
                 .map_err(CommandError::from)
                 .with_context(|_| WriteRangeSnafu {
                     chunk: None,
-                    path: path.clone(),
+                    path: self.path.clone(),
                 })?;
 
-            file.write_all(&data)
-                .map_err(CommandError::from)
-                .with_context(|_| WriteRangeSnafu { chunk: None, path })?;
+            let path = self.path.clone();
+            blocking::unblock(move || {
+                file.seek(SeekFrom::Start(range.start))
+                    .map_err(CommandError::from)
+                    .with_context(|_| WriteRangeSnafu {
+                        chunk: None,
+                        path: path.clone(),
+                    })?;
 
-            Ok::<_, FileWriterError>(())
+                file.write_all(&data)
+                    .map_err(CommandError::from)
+                    .with_context(|_| WriteRangeSnafu { chunk: None, path })?;
+
+                Ok::<_, FileWriterError>(())
+            })
+            .await
         })
-        .await
     }
 
-    async fn finalize(mut self) -> Result<(), FileWriterError> {
-        self.inject_delay(0).await;
+    fn finalize(self) -> FileWriterFuture<'static> {
+        Box::pin(async move {
+            self.inject_delay(0).await;
 
-        let path = self.path.clone();
-        blocking::unblock(move || {
-            self.file
-                .sync_all()
-                .map_err(CommandError::from)
-                .with_context(|_| FinalizeSnafu { path })?;
-            Ok::<_, FileWriterError>(())
+            let path = self.path.clone();
+            blocking::unblock(move || {
+                self.file
+                    .sync_all()
+                    .map_err(CommandError::from)
+                    .with_context(|_| FinalizeSnafu { path })?;
+                Ok::<_, FileWriterError>(())
+            })
+            .await
         })
-        .await
     }
 }

--- a/crates/bolt-load/src/task/instance/concurrent_task/mod.rs
+++ b/crates/bolt-load/src/task/instance/concurrent_task/mod.rs
@@ -9,7 +9,7 @@ use std::{
 use async_waitgroup::WaitGroup;
 use bolt_load_core::adapter::AdapterError;
 use bolt_load_utils::telemetry::*;
-use futures::{FutureExt, task::SpawnExt};
+use futures::{FutureExt, future::Either, task::SpawnExt};
 use runner_manager::TaskState;
 use smol_cancellation_token::CancellationToken;
 use statig::prelude::*;
@@ -534,6 +534,9 @@ impl ConcurrentTaskInner {
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     async fn download(&mut self, cancel_token: &CancellationToken) -> Result<()> {
+        use file_writer::{PendingWriter, WriteCompletion, WriterFullError};
+        use runner_manager::RunnerTick;
+
         let total = self
             .progress
             .total
@@ -560,32 +563,99 @@ impl ConcurrentTaskInner {
         let mut per_runner_avg_speed = 0.0;
 
         let (tmp_path, file_writer) = self.create_file_writer().await?;
+        let mut pending_writer = PendingWriter::new(
+            Arc::new(file_writer.clone()),
+            rt.clone(),
+            initial_max_concurrency,
+        );
 
         let mut throughout_meter_timer = rt.create_delayed_timer(DEFAULT_SAMPLE_INTERVAL);
         let mut strategy_timer = rt.create_delayed_timer(DEFAULT_STRATEGY_TICK_INTERVAL);
 
+        fn check_completions(completions: Vec<WriteCompletion>) -> Result<()> {
+            for completion in completions {
+                if let Err(error) = completion.result {
+                    return Err(TaskInstanceError::new_failed(TaskError::Other {
+                        message: format!("write failed at {:?}: {error}", completion.range),
+                    }));
+                }
+            }
+            Ok(())
+        }
+
+        enum LoopEvent {
+            WriterCompleted(Option<Vec<WriteCompletion>>),
+            StrategyTimer,
+            ThroughputTimer,
+            Runner(RunnerTick),
+        }
+
         let event_loop_result: Result<()> = async {
             loop {
-                futures::select_biased! {
-                    _ = strategy_timer.tick().fuse() => {
+                check_completions(pending_writer.try_tick())
+                    .inspect_err(|_| runners_cancel_token.cancel())?;
+
+                let can_write = pending_writer.can_write();
+
+                let event = {
+                    let writer_fut = if pending_writer.is_idle() {
+                        Either::Left(futures::future::pending::<Option<Vec<WriteCompletion>>>())
+                    } else {
+                        Either::Right(pending_writer.tick())
+                    }
+                    .fuse();
+
+                    let runner_fut = if can_write {
+                        Either::Left(runner_manager.tick(&mut meters))
+                    } else {
+                        Either::Right(runner_manager.tick_lifecycle_only(&mut meters))
+                    }
+                    .fuse();
+
+                    let strategy_tick = strategy_timer.tick().fuse();
+                    let throughput_tick = throughout_meter_timer.tick().fuse();
+
+                    futures::pin_mut!(writer_fut, runner_fut, strategy_tick, throughput_tick);
+
+                    futures::select_biased! {
+                        completions = writer_fut => LoopEvent::WriterCompleted(completions),
+                        _ = strategy_tick => LoopEvent::StrategyTimer,
+                        _ = throughput_tick => LoopEvent::ThroughputTimer,
+                        tick = runner_fut => LoopEvent::Runner(tick),
+                    }
+                };
+
+                match event {
+                    LoopEvent::WriterCompleted(Some(completions)) => {
+                        check_completions(completions)
+                            .inspect_err(|_| runners_cancel_token.cancel())?;
+                    }
+                    LoopEvent::WriterCompleted(None) => {
+                        runners_cancel_token.cancel();
+                        return Err(TaskInstanceError::new_failed(TaskError::Other {
+                            message: "writer completion channel closed unexpectedly".to_string(),
+                        }));
+                    }
+                    LoopEvent::StrategyTimer => {
                         Self::strategy_control_timer_tick(
                             &mut runner_manager,
                             &mut strategy_control,
                             &mut max_concurrency,
-
                             &rt,
                             &adapter,
                             &runners_cancel_token,
                             &wg,
-
                             current_speed,
                             per_runner_avg_speed,
-                        ).await.inspect_err(|e| {
+                        )
+                        .await
+                        .inspect_err(|e| {
                             error!("failed to download strategy timer tick: {e:?}");
+                            runners_cancel_token.cancel();
                             self.sync_progress(&runner_manager);
                         })?;
                     }
-                    _ = throughout_meter_timer.tick().fuse() => {
+                    LoopEvent::ThroughputTimer => {
                         Self::throughout_meter_tick(
                             &rt,
                             &wg,
@@ -597,17 +667,19 @@ impl ConcurrentTaskInner {
                             &event_tx,
                         );
                     }
-                    tick = runner_manager.tick(&mut meters).fuse() => {
+                    LoopEvent::Runner(tick) => {
                         if let Some(chunk) = tick.downloaded {
-                            let file_writer = file_writer.clone();
-                            let wg = wg.clone();
-                            rt.spawn(async move {
-                                let _wg = wg;
-                                if let Err(e) = file_writer.write_range(chunk.range, chunk.bytes).await {
-                                    // TODO: notify the task to stop
-                                    error!("failed to write to file: {e:?}");
-                                }
-                            }).expect("should never spawn failed");
+                            pending_writer
+                                .write_range(chunk.range, chunk.bytes)
+                                .map_err(|error: WriterFullError| {
+                                    TaskInstanceError::new_failed(TaskError::Other {
+                                        message: format!(
+                                            "writer rejected write (invariant violation): {:?}",
+                                            error.0.range
+                                        ),
+                                    })
+                                })
+                                .inspect_err(|_| runners_cancel_token.cancel())?;
                         }
                         if tick.state == TaskState::Finished {
                             break;
@@ -618,12 +690,19 @@ impl ConcurrentTaskInner {
             Ok(())
         }
         .await;
+
+        if event_loop_result.is_err() {
+            runners_cancel_token.cancel();
+        }
         self.sync_progress(&runner_manager);
 
-        // Wait all message handlers to finish
         wg.wait().await;
 
+        let flush_result = check_completions(pending_writer.flush().await);
+        drop(pending_writer);
+
         event_loop_result?;
+        flush_result?;
 
         // TODO: add a finalizing state?
         file_writer.finalize().await.map_err(|e| {

--- a/crates/bolt-load/src/task/instance/concurrent_task/runner_manager.rs
+++ b/crates/bolt-load/src/task/instance/concurrent_task/runner_manager.rs
@@ -636,12 +636,58 @@ impl RunnerManager {
         }
         RunnerTick::downloading()
     }
+
+    pub(super) async fn tick_lifecycle_only(
+        &mut self,
+        meters: &mut HashMap<RunnerId, usize>,
+    ) -> RunnerTick {
+        let next_lifecycle = self.lifecycle_aggregator.next().fuse();
+        let pending = self.pending_runners.next().fuse();
+        futures::pin_mut!(next_lifecycle, pending);
+
+        futures::select_biased! {
+            event = next_lifecycle => {
+                if let Some(event) = event {
+                    match event {
+                        LifecycleStreamEvent::Event(tagged) => {
+                            if self.handle_lifecycle(tagged, meters) {
+                                return RunnerTick::finished();
+                            }
+                        }
+                        LifecycleStreamEvent::Closed(runner_id) => {
+                            warn!("runner {runner_id} lifecycle stream closed unexpectedly");
+                            if self.handle_runner_lost(runner_id, meters) {
+                                return RunnerTick::finished();
+                            }
+                        }
+                    }
+                }
+            }
+            pending = pending => {
+                match pending {
+                    Some(pending) => {
+                        self.handle_pending(pending);
+                    }
+                    None => {
+                        if self.chunk_planner.is_complete() {
+                            return RunnerTick::finished();
+                        }
+                    }
+                }
+            }
+        }
+        RunnerTick::downloading()
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use bytes::Bytes;
+
     use super::{super::chunk_planner::ChunkStatus, *};
-    use crate::runner::{DataFrame, LifecycleEvent, RunnerConnectorError};
+    use crate::runner::{
+        DataFrame, LifecycleEvent, RunnerConnectorError, StoppedReason, TaskError,
+    };
 
     #[test]
     fn test_runner_manager_creation() {
@@ -861,5 +907,50 @@ mod tests {
 
         // Verify runner state is removed (failed)
         assert!(manager.get_runner_state(0).is_none());
+    }
+
+    #[tokio::test]
+    async fn test_lifecycle_only_tick_handles_stopped_during_writer_backpressure() {
+        use async_ringbuf::{
+            AsyncHeapRb,
+            traits::{AsyncProducer, Split},
+        };
+
+        let mut manager = RunnerManager::new(256, 1);
+        let runner_id = 0;
+        let _registration = manager.allocate_runner_with_chunk(0..256).unwrap();
+
+        let data_rb = AsyncHeapRb::<DataFrame>::new(crate::runner::DATA_FRAME_CHANNEL_CAPACITY);
+        let (mut data_prod, data_rx) = data_rb.split();
+        let lifecycle_rb =
+            AsyncHeapRb::<LifecycleEvent>::new(crate::runner::LIFECYCLE_CHANNEL_CAPACITY);
+        let (mut lifecycle_prod, lifecycle_rx) = lifecycle_rb.split();
+
+        manager.register_runner_channels(runner_id, lifecycle_rx, data_rx);
+        data_prod
+            .push(DataFrame {
+                data: Bytes::from(vec![1; 64]),
+            })
+            .await
+            .unwrap();
+        lifecycle_prod
+            .push(LifecycleEvent::Stopped(StoppedReason::Failed(
+                TaskError::Cancelled,
+            )))
+            .await
+            .unwrap();
+
+        let mut meters = HashMap::new();
+        let tick = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            manager.tick_lifecycle_only(&mut meters),
+        )
+        .await
+        .expect("lifecycle-only tick should not wait for writer capacity");
+
+        assert_eq!(tick.state, TaskState::Downloading);
+        assert!(tick.downloaded.is_none());
+        assert!(manager.get_runner_state(runner_id).is_none());
+        assert_eq!(manager.get_available_ranges(), vec![0..256]);
     }
 }


### PR DESCRIPTION
## Summary
- add `PendingWriter` to bound concurrent file writes and report write completion failures
- gate concurrent task data polling when the writer is saturated while still polling runner lifecycle/pending events
- cover backpressure with pending-writer unit tests and a slow-writer multi-runner integrity test

## Validation
- `cargo fmt`
- `git diff --check`
- `cargo test -p bolt-load pending_writer`
- `cargo test -p bolt-load test_lifecycle_only_tick_handles_stopped_during_writer_backpressure`
- `cargo test -p bolt-load test_slow_writer_backpressure_multi_runner_byte_integrity`
- `cargo test -p bolt-load`